### PR TITLE
feat(push): web push pipeline + /settings/alerts opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,15 @@ OPENSKY_CLIENT_SECRET=
 SS_REGION_LAT=47.6
 SS_REGION_LON=-122.3
 SS_REGION_NM=80
+
+# CRON_SECRET protects /api/cron/* — Vercel cron sends a Bearer header.
+# Generate with: openssl rand -hex 32
+CRON_SECRET=
+
+# Web Push (VAPID). Generate with: npx web-push generate-vapid-keys
+# NEXT_PUBLIC_VAPID_PUBLIC_KEY is shipped to the browser; the private key
+# stays server-only. VAPID_SUBJECT is the contact mailto a push provider
+# uses to reach us about subscription issues.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:adavenport321@gmail.com

--- a/app/(tabs)/settings/alerts/page.tsx
+++ b/app/(tabs)/settings/alerts/page.tsx
@@ -1,0 +1,12 @@
+import { AlertsSettings } from "@/components/AlertsSettings";
+
+export const metadata = {
+  title: "Alerts",
+  description: "Get a ping when the bird's up.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default function AlertsPage() {
+  return <AlertsSettings />;
+}

--- a/app/admin/Editor.tsx
+++ b/app/admin/Editor.tsx
@@ -120,6 +120,10 @@ export function Editor({
         <FlagsForm enabled={flags.speedWarningEnabled} />
       </Section>
 
+      <Section title="Push" subtitle="broadcast test ping">
+        <PushTestButton />
+      </Section>
+
       <Section title="Backups" subtitle={`${backups.length} most recent`}>
         {backups.length === 0 ? (
           <Empty>No backups yet — they&rsquo;re created automatically on every save.</Empty>
@@ -936,6 +940,42 @@ function RoleConfidenceSelect({
           </option>
         ))}
       </select>
+    </div>
+  );
+}
+
+function PushTestButton() {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const click = async () => {
+    if (busy) return;
+    if (!confirm("Broadcast a test push to ALL opted-in subscriptions?")) return;
+    setBusy(true);
+    setResult(null);
+    try {
+      const r = await fetch("/api/push/test", { method: "POST" });
+      const data = (await r.json()) as { sent?: number; removed?: number; error?: string };
+      if (!r.ok) {
+        setResult(`Failed: ${data.error ?? r.status}`);
+      } else {
+        setResult(`Sent ${data.sent ?? 0} · pruned ${data.removed ?? 0}`);
+      }
+    } catch (e) {
+      setResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <button type="button" onClick={click} style={smallButtonStyle} disabled={busy}>
+        {busy ? "Sending…" : "Broadcast test ping"}
+      </button>
+      {result && (
+        <span className="ss-mono" style={{ fontSize: 11, color: SS_TOKENS.fg2 }}>
+          {result}
+        </span>
+      )}
     </div>
   );
 }

--- a/app/api/push/prefs/route.ts
+++ b/app/api/push/prefs/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { updatePrefs, type AlertPrefs } from "@/lib/push/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
+  }
+  const b = body as { id?: unknown; prefs?: Partial<AlertPrefs> };
+  if (typeof b.id !== "string" || !b.id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+  if (!b.prefs || typeof b.prefs !== "object") {
+    return NextResponse.json({ error: "missing_prefs" }, { status: 400 });
+  }
+  try {
+    const next = await updatePrefs(b.id, b.prefs);
+    if (!next) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, prefs: next.prefs });
+  } catch (e) {
+    console.warn("[push/prefs] failed:", e);
+    return NextResponse.json({ error: "update_failed" }, { status: 500 });
+  }
+}

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { saveSubscription, type AlertPrefs } from "@/lib/push/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isPushSubscriptionJSON(v: unknown): v is PushSubscriptionJSON {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.endpoint !== "string" || !o.endpoint.startsWith("https://"))
+    return false;
+  if (!o.keys || typeof o.keys !== "object") return false;
+  const k = o.keys as Record<string, unknown>;
+  return typeof k.p256dh === "string" && typeof k.auth === "string";
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
+  }
+  const b = body as { sub?: unknown; prefs?: Partial<AlertPrefs> };
+  if (!isPushSubscriptionJSON(b.sub)) {
+    return NextResponse.json({ error: "invalid_subscription" }, { status: 400 });
+  }
+  try {
+    const id = await saveSubscription(b.sub, b.prefs);
+    return NextResponse.json({ ok: true, id });
+  } catch (e) {
+    console.warn("[push/subscribe] save failed:", e);
+    return NextResponse.json({ error: "save_failed" }, { status: 500 });
+  }
+}

--- a/app/api/push/test/route.ts
+++ b/app/api/push/test/route.ts
@@ -1,0 +1,93 @@
+// Admin-only: send a one-off test notification to a specific subscription
+// (when `id` is provided) or to every active subscription (when omitted).
+// Use the broadcast variant sparingly — it pings every opted-in rider.
+//
+// Riders verifying their own subscription should use the local-only test
+// button on /settings/alerts (showLocalTestNotification) — that path does
+// NOT require admin and doesn't go through the Push service.
+
+import webpush from "web-push";
+import { NextResponse } from "next/server";
+import { isAdminAuthed } from "@/lib/admin-auth";
+import {
+  getSubscription,
+  listSubscriptions,
+  removeSubscription,
+} from "@/lib/push/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const TEST_PAYLOAD = {
+  title: "Smokey · test",
+  body: "Channel 19. Test ping. 10-4.",
+  tag: "smokey-test",
+  data: { url: "/settings/alerts" },
+};
+
+function ensureVapidConfigured(): boolean {
+  const pub = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  const priv = process.env.VAPID_PRIVATE_KEY;
+  const subj = process.env.VAPID_SUBJECT;
+  if (!pub || !priv || !subj) return false;
+  webpush.setVapidDetails(subj, pub, priv);
+  return true;
+}
+
+export async function POST(req: Request) {
+  if (!isAdminAuthed()) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  if (!ensureVapidConfigured()) {
+    return NextResponse.json(
+      { error: "vapid_not_configured" },
+      { status: 500 },
+    );
+  }
+
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* allow empty body — broadcast mode */
+  }
+  const id = (body as { id?: string }).id;
+
+  const targets = id
+    ? await (async () => {
+        const s = await getSubscription(id);
+        return s ? [s] : [];
+      })()
+    : await listSubscriptions();
+
+  if (targets.length === 0) {
+    return NextResponse.json({ ok: true, sent: 0, removed: 0 });
+  }
+
+  console.log(`[push/test] sending test to ${targets.length} subscription(s)`);
+
+  let sent = 0;
+  let removed = 0;
+  for (const t of targets) {
+    try {
+      await webpush.sendNotification(
+        t.sub as webpush.PushSubscription,
+        JSON.stringify(TEST_PAYLOAD),
+        { TTL: 60 },
+      );
+      sent++;
+    } catch (e: unknown) {
+      const status =
+        typeof e === "object" && e !== null && "statusCode" in e
+          ? Number((e as { statusCode: unknown }).statusCode)
+          : 0;
+      if (status === 404 || status === 410) {
+        await removeSubscription(t.id).catch(() => {});
+        removed++;
+      } else {
+        console.warn("[push/test] send failed:", e);
+      }
+    }
+  }
+  return NextResponse.json({ ok: true, sent, removed });
+}

--- a/app/api/push/unsubscribe/route.ts
+++ b/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { removeSubscription, subscriptionId } from "@/lib/push/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid_payload" }, { status: 400 });
+  }
+  const b = body as { sub?: PushSubscriptionJSON; id?: string };
+  let id: string | null = null;
+  if (typeof b.id === "string" && b.id) {
+    id = b.id;
+  } else if (b.sub && typeof b.sub === "object" && typeof b.sub.endpoint === "string") {
+    try {
+      id = subscriptionId(b.sub);
+    } catch {
+      /* fall through to error */
+    }
+  }
+  if (!id) {
+    return NextResponse.json({ error: "missing_id_or_sub" }, { status: 400 });
+  }
+  try {
+    await removeSubscription(id);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.warn("[push/unsubscribe] failed:", e);
+    return NextResponse.json({ error: "remove_failed" }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { BASE_URL } from "@/lib/config";
 import { IOSInstallPrompt } from "@/components/IOSInstallPrompt";
+import { SwRegistrar } from "@/components/SwRegistrar";
 import { TooltipProvider } from "@/components/Tooltip";
 import "./globals.css";
 
@@ -78,6 +79,7 @@ export default function RootLayout({
         <TooltipProvider>
           {children}
           <IOSInstallPrompt />
+          <SwRegistrar />
         </TooltipProvider>
         <Analytics />
       </body>

--- a/components/AlertsOptInCard.tsx
+++ b/components/AlertsOptInCard.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+// Dismissable opt-in card rendered at the bottom of the dashboard variant
+// (DashShell) for un-subscribed riders. Shows at most once per browser per
+// 14 days (key: ss_alerts_promo_dismissed_at). Tapping "Arm alerts" runs
+// subscribePush directly — no extra page navigation.
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { SS_TOKENS } from "@/lib/tokens";
+import {
+  getCurrentSubscriptionId,
+  isPushSupported,
+  pushAvailableInThisContext,
+  subscribePush,
+} from "@/lib/push/client";
+
+const DISMISS_KEY = "ss_alerts_promo_dismissed_at";
+const COOLDOWN_MS = 14 * 24 * 60 * 60 * 1000;
+
+type Phase = "checking" | "show" | "armed" | "hidden";
+
+export function AlertsOptInCard() {
+  const [phase, setPhase] = useState<Phase>("checking");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (typeof window === "undefined") return;
+      // Guards: feature support, iOS-PWA context, cooldown, already subscribed.
+      if (!isPushSupported() || !pushAvailableInThisContext().available) {
+        if (!cancelled) setPhase("hidden");
+        return;
+      }
+      const dismissed = Number(window.localStorage.getItem(DISMISS_KEY) ?? 0);
+      if (Number.isFinite(dismissed) && Date.now() - dismissed < COOLDOWN_MS) {
+        if (!cancelled) setPhase("hidden");
+        return;
+      }
+      const id = await getCurrentSubscriptionId();
+      if (!cancelled) setPhase(id ? "hidden" : "show");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onDismiss = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    }
+    setPhase("hidden");
+  }, []);
+
+  const onArm = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const r = await subscribePush();
+    setBusy(false);
+    if (r.ok) {
+      setPhase("armed");
+    } else if (r.reason === "denied") {
+      setError("Browser blocked alerts. Update permission in your settings.");
+    } else if (r.reason === "vapid_missing") {
+      setError("Push isn't configured on this build.");
+    } else {
+      setError("Couldn't subscribe. Try /settings/alerts.");
+    }
+  }, []);
+
+  if (phase === "checking" || phase === "hidden") return null;
+
+  if (phase === "armed") {
+    return (
+      <Wrapper>
+        <p
+          style={{
+            fontSize: 14,
+            color: SS_TOKENS.fg0,
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          10-4. Alerts armed. Tweak in{" "}
+          <Link
+            href="/settings/alerts"
+            style={{ color: SS_TOKENS.alert, textDecoration: "underline" }}
+          >
+            /settings/alerts
+          </Link>
+          .
+        </p>
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      <div
+        className="ss-mono"
+        style={{
+          fontSize: 9.5,
+          color: SS_TOKENS.fg2,
+          letterSpacing: ".12em",
+          marginBottom: 6,
+        }}
+      >
+        OPT IN
+      </div>
+      <h3
+        style={{
+          fontSize: 16,
+          fontWeight: 700,
+          color: SS_TOKENS.fg0,
+          margin: 0,
+        }}
+      >
+        Want a ping when Smokey&rsquo;s up?
+      </h3>
+      <p
+        style={{
+          fontSize: 13,
+          color: SS_TOKENS.fg1,
+          margin: "8px 0 0",
+          lineHeight: 1.45,
+        }}
+      >
+        We&rsquo;ll only ping when an alert-class bird goes up. Tweak later
+        in /settings/alerts.
+      </p>
+      {error && (
+        <p
+          style={{
+            fontSize: 12,
+            color: SS_TOKENS.danger,
+            margin: "10px 0 0",
+            lineHeight: 1.45,
+          }}
+        >
+          {error}
+        </p>
+      )}
+      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+        <button
+          type="button"
+          onClick={onArm}
+          disabled={busy}
+          style={{
+            padding: "8px 14px",
+            borderRadius: 999,
+            border: 0,
+            background: SS_TOKENS.alert,
+            color: SS_TOKENS.bg0,
+            fontFamily: "var(--font-inter)",
+            fontSize: 12.5,
+            fontWeight: 700,
+            letterSpacing: ".02em",
+            cursor: busy ? "default" : "pointer",
+            opacity: busy ? 0.6 : 1,
+            touchAction: "manipulation",
+            WebkitTapHighlightColor: "transparent",
+          }}
+        >
+          Arm alerts
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          style={{
+            padding: "8px 14px",
+            borderRadius: 999,
+            border: `.5px solid ${SS_TOKENS.hairline2}`,
+            background: "transparent",
+            color: SS_TOKENS.fg1,
+            fontFamily: "var(--font-inter)",
+            fontSize: 12.5,
+            fontWeight: 600,
+            letterSpacing: ".02em",
+            cursor: "pointer",
+            touchAction: "manipulation",
+            WebkitTapHighlightColor: "transparent",
+          }}
+        >
+          Not now
+        </button>
+      </div>
+    </Wrapper>
+  );
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <section
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 14,
+        padding: "14px 16px",
+      }}
+    >
+      {children}
+    </section>
+  );
+}

--- a/components/AlertsSettings.tsx
+++ b/components/AlertsSettings.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+// /settings/alerts — single-screen opt-in surface for push notifications.
+// Five sections: status row + tier picker + zones + quiet hours + test.
+// All copy passes the design/BRAND.md voice rules (no emoji, no '!',
+// 3–6 word headlines, ≤140 char bodies, "Smokey" with the E for the bird).
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SS_TOKENS } from "@/lib/tokens";
+import {
+  getCurrentSubscriptionId,
+  getPushPermission,
+  isPushSupported,
+  pushAvailableInThisContext,
+  showLocalTestNotification,
+  subscribePush,
+  unsubscribePush,
+  updatePushPrefs,
+} from "@/lib/push/client";
+import {
+  DEFAULT_PREFS,
+  type AlertPrefs,
+  type AlertTier,
+} from "@/lib/push/types";
+
+type LoadState = "loading" | "ready";
+
+export function AlertsSettings() {
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [supported, setSupported] = useState(true);
+  const [contextOk, setContextOk] = useState<{
+    available: boolean;
+    reason?: "ios-not-pwa" | "ios-too-old";
+  }>({ available: true });
+  const [permission, setPermission] = useState<NotificationPermission>("default");
+  const [subId, setSubId] = useState<string | null>(null);
+  const [prefs, setPrefs] = useState<AlertPrefs>(DEFAULT_PREFS);
+  const [toast, setToast] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Hydrate from current SW state on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sup = isPushSupported();
+      setSupported(sup);
+      setContextOk(pushAvailableInThisContext());
+      setPermission(getPushPermission());
+      if (sup) {
+        const id = await getCurrentSubscriptionId();
+        if (!cancelled && id) setSubId(id);
+      }
+      if (!cancelled) setLoadState("ready");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const flash = useCallback((msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3500);
+  }, []);
+
+  const onArm = useCallback(async () => {
+    setBusy(true);
+    const r = await subscribePush(prefs);
+    setBusy(false);
+    setPermission(getPushPermission());
+    if (r.ok) {
+      setSubId(r.id);
+      flash("10-4. We'll keep you posted.");
+    } else if (r.reason === "denied") {
+      flash("Browser blocked alerts. Update permission in your settings.");
+    } else if (r.reason === "vapid_missing") {
+      flash("Push isn't configured on this build. Try the live site.");
+    } else if (r.reason === "unsupported") {
+      flash("This browser doesn't support push.");
+    } else {
+      flash("Couldn't subscribe. Try again in a moment.");
+    }
+  }, [prefs, flash]);
+
+  const onDisarm = useCallback(async () => {
+    setBusy(true);
+    await unsubscribePush();
+    setBusy(false);
+    setSubId(null);
+    flash("Off the air. Channel 19 still open if you change your mind.");
+  }, [flash]);
+
+  const persistPrefs = useCallback(
+    async (next: Partial<AlertPrefs>) => {
+      const merged: AlertPrefs = { ...prefs, ...next };
+      setPrefs(merged);
+      if (!subId) return; // not yet subscribed; nothing to persist
+      const ok = await updatePushPrefs(subId, next);
+      if (!ok) flash("Couldn't save preference. Try again.");
+    },
+    [prefs, subId, flash],
+  );
+
+  const onTest = useCallback(async () => {
+    if (permission !== "granted") {
+      flash("Arm alerts first to receive the test ping.");
+      return;
+    }
+    const ok = await showLocalTestNotification();
+    if (!ok) flash("Couldn't send the test ping.");
+  }, [permission, flash]);
+
+  const statusBadge = useMemo<{ label: string; color: string; bg: string }>(() => {
+    if (!subId) return { label: "OFF", color: SS_TOKENS.fg2, bg: SS_TOKENS.bg2 };
+    if (prefs.tier === "all")
+      return { label: "ALL", color: SS_TOKENS.alert, bg: SS_TOKENS.alertDim };
+    return {
+      label: "ALERT-ONLY",
+      color: SS_TOKENS.alert,
+      bg: SS_TOKENS.alertDim,
+    };
+  }, [subId, prefs.tier]);
+
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        padding: "12px 18px 100px",
+        maxWidth: 460,
+        margin: "0 auto",
+        display: "flex",
+        flexDirection: "column",
+        gap: 18,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginTop: 4,
+        }}
+      >
+        <span className="ss-eyebrow">Alerts · Channel 19</span>
+        <Link
+          href="/"
+          className="ss-mono"
+          style={{ fontSize: 11, color: SS_TOKENS.fg1, textDecoration: "none" }}
+        >
+          ← Back
+        </Link>
+      </header>
+
+      <h1
+        style={{
+          fontSize: 28,
+          fontWeight: 800,
+          letterSpacing: "-.03em",
+          lineHeight: 1.1,
+          color: SS_TOKENS.fg0,
+          margin: 0,
+        }}
+      >
+        Get a ping when the bird&rsquo;s up.
+      </h1>
+
+      {loadState === "loading" ? (
+        <Card>
+          <p style={{ color: SS_TOKENS.fg2, fontSize: 13 }}>Checking…</p>
+        </Card>
+      ) : !supported ? (
+        <UnsupportedCard />
+      ) : !contextOk.available ? (
+        <IosNotPwaCard reason={contextOk.reason} />
+      ) : (
+        <>
+          {/* Status row */}
+          <Card>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <div>
+                <div
+                  className="ss-mono"
+                  style={{
+                    fontSize: 9.5,
+                    letterSpacing: ".12em",
+                    color: SS_TOKENS.fg2,
+                  }}
+                >
+                  STATUS
+                </div>
+                <div
+                  className="ss-mono"
+                  style={{
+                    display: "inline-block",
+                    marginTop: 6,
+                    padding: "3px 10px",
+                    borderRadius: 999,
+                    fontSize: 11,
+                    fontWeight: 700,
+                    letterSpacing: ".1em",
+                    color: statusBadge.color,
+                    background: statusBadge.bg,
+                    border: `.5px solid ${statusBadge.color}55`,
+                  }}
+                >
+                  {statusBadge.label}
+                </div>
+                {!subId && (
+                  <p
+                    style={{
+                      marginTop: 10,
+                      fontSize: 13,
+                      color: SS_TOKENS.fg2,
+                      lineHeight: 1.45,
+                    }}
+                  >
+                    Quiet skies. No alerts armed.
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={subId ? onDisarm : onArm}
+                disabled={busy || permission === "denied"}
+                style={{
+                  padding: "10px 16px",
+                  borderRadius: 999,
+                  border: 0,
+                  background: subId ? SS_TOKENS.bg2 : SS_TOKENS.alert,
+                  color: subId ? SS_TOKENS.fg1 : SS_TOKENS.bg0,
+                  fontFamily: "var(--font-inter)",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  letterSpacing: ".02em",
+                  cursor: busy || permission === "denied" ? "default" : "pointer",
+                  opacity: busy || permission === "denied" ? 0.6 : 1,
+                  touchAction: "manipulation",
+                  WebkitTapHighlightColor: "transparent",
+                }}
+              >
+                {subId ? "Disarm" : "Arm alerts"}
+              </button>
+            </div>
+
+            {permission === "denied" && (
+              <p
+                style={{
+                  marginTop: 12,
+                  fontSize: 12.5,
+                  color: SS_TOKENS.danger,
+                  lineHeight: 1.45,
+                }}
+              >
+                Your browser blocked alerts. Open Safari → Settings →
+                SmokySignal to fix.
+              </p>
+            )}
+          </Card>
+
+          {/* Tier picker */}
+          <Section eyebrow="What pings you">
+            <RadioCard
+              active={prefs.tier === "alert_only"}
+              onClick={() => persistPrefs({ tier: "alert_only" satisfies AlertTier })}
+              title="Alert only"
+              body="Bird up. Heads up."
+            />
+            <RadioCard
+              active={prefs.tier === "all"}
+              onClick={() => persistPrefs({ tier: "all" satisfies AlertTier })}
+              title="All aircraft"
+              body="Every wing in the air."
+            />
+          </Section>
+
+          {/* Zones (placeholder — per-zone opt-in needs hot-zone load; today is 'any') */}
+          <Section eyebrow="Zones">
+            <p style={{ fontSize: 13, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.45 }}>
+              Pings fire for any corridor. Per-zone filters land once your
+              local hot-zones have settled in.
+            </p>
+            <div
+              className="ss-mono"
+              style={{ fontSize: 10.5, color: SS_TOKENS.fg2, marginTop: 8, letterSpacing: ".06em" }}
+            >
+              {prefs.zones === "any"
+                ? "ANY ZONE"
+                : `${prefs.zones.length} ZONE${prefs.zones.length === 1 ? "" : "S"}`}
+            </div>
+          </Section>
+
+          {/* Quiet hours */}
+          <Section eyebrow="Quiet hours">
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <HourInput
+                value={prefs.quiet_start_h}
+                onChange={(h) => persistPrefs({ quiet_start_h: h })}
+              />
+              <span className="ss-mono" style={{ color: SS_TOKENS.fg2, fontSize: 12 }}>
+                →
+              </span>
+              <HourInput
+                value={prefs.quiet_end_h}
+                onChange={(h) => persistPrefs({ quiet_end_h: h })}
+              />
+              <span className="ss-mono" style={{ color: SS_TOKENS.fg2, fontSize: 11 }}>
+                {prefs.tz}
+              </span>
+            </div>
+            <p
+              style={{
+                marginTop: 10,
+                fontSize: 12,
+                color: SS_TOKENS.fg2,
+                lineHeight: 1.45,
+              }}
+            >
+              Channel 19 stays quiet between these hours.
+            </p>
+          </Section>
+
+          {/* Test button */}
+          <Section eyebrow="Test">
+            <button
+              type="button"
+              onClick={onTest}
+              disabled={permission !== "granted"}
+              style={{
+                padding: "8px 14px",
+                borderRadius: 999,
+                border: `.5px solid ${SS_TOKENS.hairline2}`,
+                background: SS_TOKENS.bg2,
+                color: SS_TOKENS.fg0,
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                letterSpacing: ".04em",
+                cursor: permission === "granted" ? "pointer" : "default",
+                opacity: permission === "granted" ? 1 : 0.5,
+                touchAction: "manipulation",
+                WebkitTapHighlightColor: "transparent",
+              }}
+            >
+              Send me a test ping
+            </button>
+          </Section>
+        </>
+      )}
+
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "fixed",
+            left: "50%",
+            transform: "translateX(-50%)",
+            bottom: 84,
+            padding: "10px 14px",
+            borderRadius: 999,
+            background: "rgba(11,13,16,0.92)",
+            color: SS_TOKENS.fg0,
+            border: `.5px solid ${SS_TOKENS.hairline2}`,
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            letterSpacing: ".04em",
+            zIndex: 30,
+            maxWidth: "calc(100% - 32px)",
+            textAlign: "center",
+          }}
+        >
+          {toast}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Section({
+  eyebrow,
+  children,
+}: {
+  eyebrow: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <div
+        className="ss-mono"
+        style={{
+          fontSize: 9.5,
+          color: SS_TOKENS.fg2,
+          letterSpacing: ".12em",
+          textTransform: "uppercase",
+          marginBottom: 12,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {children}
+      </div>
+    </Card>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <section
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 14,
+        padding: "14px 16px",
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+function RadioCard({
+  active,
+  onClick,
+  title,
+  body,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  body: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        textAlign: "left",
+        padding: "10px 12px",
+        borderRadius: 10,
+        background: active ? SS_TOKENS.alertDim : SS_TOKENS.bg2,
+        border: `.5px solid ${active ? `${SS_TOKENS.alert}66` : SS_TOKENS.hairline2}`,
+        color: SS_TOKENS.fg0,
+        cursor: "pointer",
+        touchAction: "manipulation",
+        WebkitTapHighlightColor: "transparent",
+        display: "flex",
+        flexDirection: "column",
+        gap: 3,
+      }}
+    >
+      <span style={{ fontSize: 13.5, fontWeight: 700, color: SS_TOKENS.fg0 }}>
+        {title}
+      </span>
+      <span style={{ fontSize: 12, color: SS_TOKENS.fg1 }}>{body}</span>
+    </button>
+  );
+}
+
+function HourInput({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (h: number) => void;
+}) {
+  return (
+    <input
+      type="number"
+      inputMode="numeric"
+      min={0}
+      max={23}
+      value={value}
+      onChange={(e) => {
+        const n = Number(e.target.value);
+        if (!Number.isFinite(n)) return;
+        const clamped = Math.max(0, Math.min(23, Math.trunc(n)));
+        onChange(clamped);
+      }}
+      className="ss-mono"
+      style={{
+        width: 56,
+        padding: "6px 8px",
+        borderRadius: 8,
+        background: SS_TOKENS.bg2,
+        border: `.5px solid ${SS_TOKENS.hairline2}`,
+        color: SS_TOKENS.fg0,
+        fontSize: 14,
+        textAlign: "center",
+      }}
+    />
+  );
+}
+
+function UnsupportedCard() {
+  return (
+    <Card>
+      <p style={{ fontSize: 13.5, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.5 }}>
+        This browser doesn&rsquo;t support push notifications. Try Chrome,
+        Firefox, or Safari on iOS 16.4+ (after Add to Home Screen).
+      </p>
+    </Card>
+  );
+}
+
+function IosNotPwaCard({
+  reason,
+}: {
+  reason?: "ios-not-pwa" | "ios-too-old";
+}) {
+  return (
+    <Card>
+      <div
+        className="ss-mono"
+        style={{
+          fontSize: 9.5,
+          color: SS_TOKENS.fg2,
+          letterSpacing: ".12em",
+          marginBottom: 8,
+        }}
+      >
+        ON IPHONE
+      </div>
+      <p style={{ fontSize: 14, color: SS_TOKENS.fg0, margin: 0, lineHeight: 1.5 }}>
+        {reason === "ios-too-old"
+          ? "iOS 16.4 or later is required for browser-based push. Update iOS to enable alerts."
+          : "Alerts only work after you Add to Home Screen. Tap Share, then Add to Home Screen, then open the app icon."}
+      </p>
+    </Card>
+  );
+}

--- a/components/DashShell.tsx
+++ b/components/DashShell.tsx
@@ -10,6 +10,7 @@ import { haversineNm, DEFAULT_SPEED_LIMIT_MPH } from "@/lib/geo";
 import { StatusPill } from "./StatusPill";
 import { Card } from "./Card";
 import { Speedometer } from "./Speedometer";
+import { AlertsOptInCard } from "./AlertsOptInCard";
 import type { Aircraft, Snapshot } from "@/lib/types";
 import type { ActivityEntry } from "@/lib/activity";
 
@@ -152,6 +153,8 @@ export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
       />
 
       <ActivityFeed entries={activity} />
+
+      <AlertsOptInCard />
     </main>
   );
 }

--- a/components/IOSInstallPrompt.tsx
+++ b/components/IOSInstallPrompt.tsx
@@ -84,6 +84,18 @@ export function IOSInstallPrompt() {
     >
       <div style={{ flex: 1, fontSize: 12.5, lineHeight: 1.45, color: SS_TOKENS.fg0 }}>
         Install SmokySignal — tap <ShareIcon /> then &ldquo;Add to Home Screen&rdquo;
+        <span
+          className="ss-mono"
+          style={{
+            display: "block",
+            marginTop: 4,
+            fontSize: 10.5,
+            color: SS_TOKENS.fg2,
+            letterSpacing: ".04em",
+          }}
+        >
+          Add to Home Screen → Open SmokySignal → arm alerts.
+        </span>
       </div>
       <button
         type="button"

--- a/components/SwRegistrar.tsx
+++ b/components/SwRegistrar.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+// Registers the static /sw.js service worker on every page load. Idempotent —
+// the browser deduplicates by scope. Silent on unsupported browsers (Safari
+// pre-16.4, anything not in `serviceWorker in navigator`).
+//
+// The SW is push-only; no offline caching. Mounted from app/layout.tsx so it
+// gets a registration handle as early as the JS bundle hydrates.
+
+import { useEffect } from "react";
+
+export function SwRegistrar() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+    navigator.serviceWorker.register("/sw.js").catch(() => {
+      /* silent — PWA install + push will fail gracefully if SW can't register */
+    });
+  }, []);
+  return null;
+}

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -245,6 +245,37 @@ export async function recordActivity(curr: Snapshot): Promise<void> {
     } catch (e) {
       console.warn("[activity] rpush failed:", e);
     }
+
+    // Fan out push notifications for each takeoff. Best-effort; the
+    // dispatcher's own try/catch + dedupe key keep this from breaking
+    // the snapshot pipeline. Fire all in parallel since the dispatcher
+    // already de-duplicates per (tail, minute).
+    const takeoffs = events.filter((e) => e.kind === "takeoff");
+    if (takeoffs.length > 0) {
+      try {
+        const { dispatchTakeoff } = await import("./push/dispatcher");
+        await Promise.all(
+          takeoffs.map((e) =>
+            dispatchTakeoff({
+              tail: e.tail,
+              role: e.role ?? "unknown",
+              roleConfidence: "unknown",
+              nickname:
+                curr.aircraft.find((a) => a.tail === e.tail)?.nickname ?? null,
+              lat: e.lat ?? null,
+              lon: e.lon ?? null,
+              alt_ft: e.alt_ft ?? null,
+              ts_iso: new Date(e.ts).toISOString(),
+            }).catch((err) => {
+              console.warn("[activity] dispatchTakeoff failed:", err);
+              return null;
+            }),
+          ),
+        );
+      } catch (e) {
+        console.warn("[activity] push dispatch import/init failed:", e);
+      }
+    }
   }
 
   try {

--- a/lib/hotzones.ts
+++ b/lib/hotzones.ts
@@ -42,6 +42,26 @@ const CURRENT_KEY = "hotzones:current";
 const LAST_REFRESH_KEY = "hotzones:last_refresh_ts";
 const TTL_SECONDS = 25 * 60 * 60;
 
+/**
+ * Stable string ID for the hot-zone cell containing (lat, lon). Same scheme
+ * used by aggregateHotZones() to bucket pings, so a rider opting into zone
+ * "${cellLat},${cellLon}" matches every airborne event whose coords fall
+ * inside the same cell. Used by the push dispatcher to filter zone-scoped
+ * subscriptions (lib/push/dispatcher.ts).
+ */
+export function zoneIdForPoint(lat: number, lon: number): string {
+  const cellLat = Math.floor(lat / GRID_CELL_DEG) * GRID_CELL_DEG;
+  const cellLon = Math.floor(lon / GRID_CELL_DEG) * GRID_CELL_DEG;
+  return `${cellLat.toFixed(4)},${cellLon.toFixed(4)}`;
+}
+
+/** Inverse of zoneIdForPoint — returns the cell origin from an ID string. */
+export function pointForZoneId(id: string): { lat: number; lon: number } | null {
+  const m = /^(-?\d+\.\d+),(-?\d+\.\d+)$/.exec(id);
+  if (!m) return null;
+  return { lat: Number(m[1]), lon: Number(m[2]) };
+}
+
 export type HotZone = {
   /** Cell centroid latitude. */
   lat: number;

--- a/lib/push/client.ts
+++ b/lib/push/client.ts
@@ -1,0 +1,217 @@
+// Browser-side push subscribe/unsubscribe helpers. Pure ESM, no React.
+// Server-side imports (lib/push/store, lib/push/dispatcher) MUST NOT pull
+// from this file — keep the SW + Push API surface client-only.
+
+import type { AlertPrefs } from "./store";
+
+export type SubscribeResult =
+  | { ok: true; id: string; sub: PushSubscription }
+  | {
+      ok: false;
+      reason: "unsupported" | "denied" | "vapid_missing" | "error";
+      error?: unknown;
+    };
+
+export function isPushSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+export function getPushPermission(): NotificationPermission {
+  if (typeof window === "undefined" || typeof Notification === "undefined") {
+    return "default";
+  }
+  return Notification.permission;
+}
+
+/**
+ * iOS Safari only allows push from a PWA installed to the home screen, and
+ * only on iOS 16.4+. Everywhere else this returns true (i.e. push works in
+ * the regular browser context).
+ */
+export function pushAvailableInThisContext(): {
+  available: boolean;
+  reason?: "ios-not-pwa" | "ios-too-old";
+} {
+  if (typeof window === "undefined") return { available: false };
+  if (!isPushSupported()) return { available: false };
+  const ua = navigator.userAgent;
+  const isIos = /iPhone|iPad|iPod/.test(ua);
+  if (!isIos) return { available: true };
+  // iOS PWA detection: standalone display-mode
+  const standalone =
+    (window.matchMedia &&
+      window.matchMedia("(display-mode: standalone)").matches) ||
+    // legacy iOS Safari
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  if (!standalone) return { available: false, reason: "ios-not-pwa" };
+  return { available: true };
+}
+
+/** Decode a base64url-encoded VAPID public key into the Uint8Array Push wants. */
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
+
+async function ensureRegistration(): Promise<ServiceWorkerRegistration> {
+  // SwRegistrar mounts on every page so this should be a no-op in practice;
+  // do it again here as belt-and-suspenders for direct calls before mount.
+  return navigator.serviceWorker.register("/sw.js");
+}
+
+export async function subscribePush(
+  prefsPartial?: Partial<AlertPrefs>,
+): Promise<SubscribeResult> {
+  if (!isPushSupported()) return { ok: false, reason: "unsupported" };
+  const vapid = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!vapid) return { ok: false, reason: "vapid_missing" };
+
+  try {
+    const reg = await ensureRegistration();
+    const perm = await Notification.requestPermission();
+    if (perm !== "granted") return { ok: false, reason: "denied" };
+
+    const sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      // The Push API typing on this DOM lib version wants a strict
+      // BufferSource; the fresh-allocated Uint8Array satisfies that
+      // structurally but trips TS's variance check. Cast is safe.
+      applicationServerKey: urlBase64ToUint8Array(vapid) as BufferSource,
+    });
+
+    const r = await fetch("/api/push/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sub: sub.toJSON(),
+        prefs: { ...prefsPartial, tz: detectTz(prefsPartial?.tz) },
+      }),
+    });
+    if (!r.ok) {
+      // Rollback the browser-side subscription so we don't leave a dangling
+      // endpoint the server doesn't know about.
+      try {
+        await sub.unsubscribe();
+      } catch {
+        /* best-effort */
+      }
+      return { ok: false, reason: "error", error: await safeText(r) };
+    }
+    const { id } = (await r.json()) as { id: string };
+    return { ok: true, id, sub };
+  } catch (error) {
+    return { ok: false, reason: "error", error };
+  }
+}
+
+export async function unsubscribePush(): Promise<void> {
+  if (!isPushSupported()) return;
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (!reg) return;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return;
+    const json = sub.toJSON();
+    await sub.unsubscribe().catch(() => {
+      /* tolerate browser quirk */
+    });
+    await fetch("/api/push/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sub: json }),
+    }).catch(() => {
+      /* best-effort */
+    });
+  } catch {
+    /* silent — UI will reflect from getSubscription() polling */
+  }
+}
+
+export async function getCurrentSubscriptionId(): Promise<string | null> {
+  if (!isPushSupported()) return null;
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (!reg) return null;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return null;
+    // The id is a sha256 hash of the endpoint — duplicate the hashing logic
+    // from store.ts client-side so we don't need a roundtrip just to know
+    // who we are. crypto.subtle is the only way to compute a hash in the
+    // browser.
+    const enc = new TextEncoder().encode(sub.endpoint);
+    const buf = await crypto.subtle.digest("SHA-256", enc);
+    const hex = Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, 24);
+    return hex;
+  } catch {
+    return null;
+  }
+}
+
+export async function updatePushPrefs(
+  id: string,
+  prefs: Partial<AlertPrefs>,
+): Promise<boolean> {
+  try {
+    const r = await fetch("/api/push/prefs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, prefs: { ...prefs, tz: detectTz(prefs.tz) } }),
+    });
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Sends a local-only test notification through the registered SW — used by
+ * the user-facing test button on /settings/alerts. Doesn't go through the
+ * server / Push service, so no admin auth needed.
+ */
+export async function showLocalTestNotification(): Promise<boolean> {
+  if (!isPushSupported()) return false;
+  try {
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (!reg) return false;
+    if (Notification.permission !== "granted") return false;
+    await reg.showNotification("Smokey · test", {
+      body: "Channel 19. Test ping. 10-4.",
+      icon: "/icons/icon-192.png",
+      badge: "/icons/favicon-96.png",
+      tag: "smokey-test",
+      data: { url: "/settings/alerts" },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectTz(prefer?: string): string {
+  if (prefer) return prefer;
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "America/Los_Angeles";
+  } catch {
+    return "America/Los_Angeles";
+  }
+}
+
+async function safeText(r: Response): Promise<string> {
+  try {
+    return await r.text();
+  } catch {
+    return `${r.status}`;
+  }
+}

--- a/lib/push/client.ts
+++ b/lib/push/client.ts
@@ -2,7 +2,7 @@
 // Server-side imports (lib/push/store, lib/push/dispatcher) MUST NOT pull
 // from this file — keep the SW + Push API surface client-only.
 
-import type { AlertPrefs } from "./store";
+import type { AlertPrefs } from "./types";
 
 export type SubscribeResult =
   | { ok: true; id: string; sub: PushSubscription }

--- a/lib/push/dispatcher.ts
+++ b/lib/push/dispatcher.ts
@@ -1,0 +1,237 @@
+// Push dispatcher. Called once per grounded→airborne transition from the
+// snapshot regen path (lib/activity.ts → recordActivity). For each takeoff
+// we compose a role-aware payload, fan out to every opted-in subscription
+// matching tier + zone + quiet-hours, and best-effort send via web-push.
+// Dead endpoints (HTTP 410/404) are pruned from KV. Failures never throw —
+// the snapshot pipeline must keep flowing.
+
+import webpush from "web-push";
+import { getRedis } from "../cache";
+import { zoneIdForPoint } from "../hotzones";
+import {
+  listSubscriptions,
+  removeSubscription,
+  type AlertPrefs,
+  type StoredSubscription,
+} from "./store";
+import type { FleetRole, RoleConfidence } from "../types";
+
+const DEDUPE_PREFIX = "push:dispatched:";
+const DEDUPE_TTL_SECONDS = 6 * 60 * 60;
+const MAX_BODY_CHARS = 140;
+
+const ALERT_ROLES: ReadonlySet<FleetRole> = new Set([
+  "smokey",
+  "patrol",
+  "unknown",
+]);
+
+let vapidConfigured = false;
+function ensureVapid(): boolean {
+  if (vapidConfigured) return true;
+  const pub = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  const priv = process.env.VAPID_PRIVATE_KEY;
+  const subj = process.env.VAPID_SUBJECT;
+  if (!pub || !priv || !subj) return false;
+  webpush.setVapidDetails(subj, pub, priv);
+  vapidConfigured = true;
+  return true;
+}
+
+export type DispatchTakeoffArgs = {
+  tail: string;
+  role: FleetRole;
+  roleConfidence: RoleConfidence;
+  nickname: string | null;
+  /**
+   * Coordinates at the moment of takeoff. Used for zone matching and
+   * (where available) corridor labelling in the body. Null is tolerated;
+   * we just skip zone filters and drop the corridor field.
+   */
+  lat: number | null;
+  lon: number | null;
+  alt_ft: number | null;
+  /** ISO timestamp of takeoff. Used to compute the dedupe key. */
+  ts_iso: string;
+};
+
+export type DispatchResult = {
+  sent: number;
+  skipped: number;
+  removed: number;
+  reason?: string;
+};
+
+export async function dispatchTakeoff(
+  args: DispatchTakeoffArgs,
+): Promise<DispatchResult> {
+  if (!ensureVapid()) {
+    return { sent: 0, skipped: 0, removed: 0, reason: "vapid_not_configured" };
+  }
+
+  const dedupeKey = buildDedupeKey(args.tail, args.ts_iso);
+  const redis = await getRedis();
+  if (redis) {
+    const already = await redis.get(`${DEDUPE_PREFIX}${dedupeKey}`);
+    if (already) return { sent: 0, skipped: 0, removed: 0, reason: "duplicate" };
+    await redis.set(`${DEDUPE_PREFIX}${dedupeKey}`, "1", {
+      ex: DEDUPE_TTL_SECONDS,
+    });
+  }
+
+  const subs = await listSubscriptions();
+  if (subs.length === 0) {
+    return { sent: 0, skipped: 0, removed: 0, reason: "no_subs" };
+  }
+
+  const payload = composePayload(args);
+  const aircraftZone =
+    args.lat != null && args.lon != null
+      ? zoneIdForPoint(args.lat, args.lon)
+      : null;
+
+  let sent = 0;
+  let skipped = 0;
+  let removed = 0;
+  for (const stored of subs) {
+    const skip = shouldSkip(stored.prefs, args.role, aircraftZone);
+    if (skip) {
+      skipped++;
+      continue;
+    }
+    const result = await sendOne(stored, payload);
+    if (result === "sent") sent++;
+    else if (result === "removed") removed++;
+    else skipped++;
+  }
+  return { sent, skipped, removed };
+}
+
+function buildDedupeKey(tail: string, tsIso: string): string {
+  // Round to the nearest minute so a 10s poll cadence can't fire two
+  // distinct dedupe keys for the same takeoff event.
+  const ts = Date.parse(tsIso);
+  const minute = Number.isFinite(ts)
+    ? Math.floor(ts / 60_000) * 60_000
+    : Math.floor(Date.now() / 60_000) * 60_000;
+  return `${tail}:${minute}`;
+}
+
+function shouldSkip(
+  prefs: AlertPrefs,
+  role: FleetRole,
+  aircraftZone: string | null,
+): boolean {
+  // tier
+  if (prefs.tier === "alert_only" && !ALERT_ROLES.has(role)) return true;
+  // zone
+  if (Array.isArray(prefs.zones) && prefs.zones.length > 0) {
+    if (aircraftZone == null) return true;
+    if (!prefs.zones.includes(aircraftZone)) return true;
+  }
+  // quiet hours
+  if (insideQuietHours(prefs)) return true;
+  return false;
+}
+
+function insideQuietHours(prefs: AlertPrefs): boolean {
+  const start = prefs.quiet_start_h;
+  const end = prefs.quiet_end_h;
+  if (start === end) return false; // zero-length window = always firing
+  let hour: number;
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: prefs.tz,
+      hour: "numeric",
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(new Date());
+    const h = parts.find((p) => p.type === "hour")?.value ?? "0";
+    hour = Number(h) % 24;
+  } catch {
+    // bad TZ → fall back to UTC; quiet hours are advisory at best in that case
+    hour = new Date().getUTCHours();
+  }
+  if (start < end) {
+    return hour >= start && hour < end;
+  }
+  // wrap-around: e.g. 23 → 6
+  return hour >= start || hour < end;
+}
+
+type PushPayload = {
+  title: string;
+  body: string;
+  tag: string;
+  data: Record<string, unknown>;
+};
+
+function composePayload(args: DispatchTakeoffArgs): PushPayload {
+  const name = args.nickname ?? args.tail;
+  const altStr = args.alt_ft != null ? `${args.alt_ft.toLocaleString()}'` : "alt unk";
+  let title: string;
+  let body: string;
+  switch (args.role) {
+    case "smokey":
+      title = "Smokey's up.";
+      body = trimBody(`${name} watching. ${altStr}.`);
+      break;
+    case "patrol":
+      title = "Eyes up.";
+      body = trimBody(`${name} airborne. ${altStr}.`);
+      break;
+    case "unknown":
+      title = "Eyes up.";
+      body = trimBody(`Unidentified bird airborne. ${altStr}.`);
+      break;
+    case "sar":
+      title = "SAR run.";
+      body = trimBody(`${name} on a rescue run.`);
+      break;
+    case "transport":
+      title = "Transport up.";
+      body = trimBody(`${name} airborne. ${altStr}.`);
+      break;
+  }
+  return {
+    title,
+    body,
+    tag: `smokey-${args.tail}`,
+    data: { url: `/plane/${args.tail}`, tail: args.tail, role: args.role },
+  };
+}
+
+function trimBody(s: string): string {
+  if (s.length <= MAX_BODY_CHARS) return s;
+  return s.slice(0, MAX_BODY_CHARS - 1) + "…";
+}
+
+type SendResult = "sent" | "removed" | "skipped";
+
+async function sendOne(
+  stored: StoredSubscription,
+  payload: PushPayload,
+): Promise<SendResult> {
+  try {
+    const sub = stored.sub as webpush.PushSubscription;
+    if (!sub.endpoint) return "skipped";
+    await webpush.sendNotification(sub, JSON.stringify(payload), { TTL: 600 });
+    return "sent";
+  } catch (e: unknown) {
+    const status =
+      typeof e === "object" && e !== null && "statusCode" in e
+        ? Number((e as { statusCode: unknown }).statusCode)
+        : 0;
+    if (status === 404 || status === 410) {
+      // Subscription is dead at the push service — prune.
+      try {
+        await removeSubscription(stored.id);
+      } catch {
+        /* best-effort */
+      }
+      return "removed";
+    }
+    console.warn(`[push] send failed for ${stored.id}:`, e);
+    return "skipped";
+  }
+}

--- a/lib/push/store.ts
+++ b/lib/push/store.ts
@@ -12,43 +12,15 @@
 
 import { createHash } from "node:crypto";
 import { getRedis } from "../cache";
+import { DEFAULT_PREFS, type AlertPrefs, type StoredSubscription } from "./types";
 
-export type AlertTier = "all" | "alert_only";
-
-export type AlertPrefs = {
-  /**
-   * 'alert_only' (default) → only fire pushes for smokey + patrol + unknown
-   * (matches computeStatus() alert tiers). 'all' also fires for sar +
-   * transport so curious riders can hear about every wing in the air.
-   */
-  tier: AlertTier;
-  /**
-   * 'any' → push for any qualifying takeoff regardless of where it happens.
-   * Otherwise an array of hot-zone cell IDs the rider has opted into.
-   */
-  zones: string[] | "any";
-  /** Rider-local hour at which quiet hours START (24-hour, 0-23). */
-  quiet_start_h: number;
-  /** Rider-local hour at which quiet hours END (24-hour, 0-23). */
-  quiet_end_h: number;
-  /** IANA TZ name; rider browser supplies it via Intl.DateTimeFormat. */
-  tz: string;
-};
-
-export const DEFAULT_PREFS: AlertPrefs = {
-  tier: "alert_only",
-  zones: "any",
-  quiet_start_h: 23,
-  quiet_end_h: 6,
-  tz: "America/Los_Angeles",
-};
-
-export type StoredSubscription = {
-  id: string;
-  sub: PushSubscriptionJSON;
-  prefs: AlertPrefs;
-  savedAt: number;
-};
+// Re-export so server-side callers can keep their existing import sites.
+export {
+  DEFAULT_PREFS,
+  type AlertPrefs,
+  type AlertTier,
+  type StoredSubscription,
+} from "./types";
 
 const SUB_PREFIX = "push:sub:";
 const SUBS_INDEX = "push:subs";

--- a/lib/push/store.ts
+++ b/lib/push/store.ts
@@ -1,0 +1,167 @@
+// Push subscription storage in KV. Each subscription is keyed by a stable
+// hash of its endpoint URL — that's a Push-service URL (e.g. fcm.googleapis,
+// web.push.apple) which already isn't personally identifying, so we don't
+// store browser fingerprints, IPs, or any rider PII. Just the endpoint +
+// p256dh + auth keys we need to send a push, plus the rider's preferences.
+//
+// Storage shape:
+//   push:sub:${id}       JSON { sub, prefs, savedAt } — 90-day TTL
+//   push:subs            Redis SET of subscription IDs (no TTL, manually pruned
+//                        when removeSubscription() runs or the dispatcher hits
+//                        a 410/404 and culls a dead endpoint)
+
+import { createHash } from "node:crypto";
+import { getRedis } from "../cache";
+
+export type AlertTier = "all" | "alert_only";
+
+export type AlertPrefs = {
+  /**
+   * 'alert_only' (default) → only fire pushes for smokey + patrol + unknown
+   * (matches computeStatus() alert tiers). 'all' also fires for sar +
+   * transport so curious riders can hear about every wing in the air.
+   */
+  tier: AlertTier;
+  /**
+   * 'any' → push for any qualifying takeoff regardless of where it happens.
+   * Otherwise an array of hot-zone cell IDs the rider has opted into.
+   */
+  zones: string[] | "any";
+  /** Rider-local hour at which quiet hours START (24-hour, 0-23). */
+  quiet_start_h: number;
+  /** Rider-local hour at which quiet hours END (24-hour, 0-23). */
+  quiet_end_h: number;
+  /** IANA TZ name; rider browser supplies it via Intl.DateTimeFormat. */
+  tz: string;
+};
+
+export const DEFAULT_PREFS: AlertPrefs = {
+  tier: "alert_only",
+  zones: "any",
+  quiet_start_h: 23,
+  quiet_end_h: 6,
+  tz: "America/Los_Angeles",
+};
+
+export type StoredSubscription = {
+  id: string;
+  sub: PushSubscriptionJSON;
+  prefs: AlertPrefs;
+  savedAt: number;
+};
+
+const SUB_PREFIX = "push:sub:";
+const SUBS_INDEX = "push:subs";
+const SUB_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+export function subscriptionId(sub: PushSubscriptionJSON): string {
+  if (!sub.endpoint) throw new Error("subscription endpoint missing");
+  return createHash("sha256").update(sub.endpoint).digest("hex").slice(0, 24);
+}
+
+function mergePrefs(partial?: Partial<AlertPrefs>): AlertPrefs {
+  if (!partial) return { ...DEFAULT_PREFS };
+  return {
+    tier: partial.tier === "all" ? "all" : "alert_only",
+    zones: Array.isArray(partial.zones) ? partial.zones : "any",
+    quiet_start_h: clampHour(partial.quiet_start_h, DEFAULT_PREFS.quiet_start_h),
+    quiet_end_h: clampHour(partial.quiet_end_h, DEFAULT_PREFS.quiet_end_h),
+    tz: typeof partial.tz === "string" && partial.tz ? partial.tz : DEFAULT_PREFS.tz,
+  };
+}
+
+function clampHour(v: unknown, fallback: number): number {
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  const i = Math.trunc(n);
+  if (i < 0 || i > 23) return fallback;
+  return i;
+}
+
+export async function saveSubscription(
+  sub: PushSubscriptionJSON,
+  prefsPartial?: Partial<AlertPrefs>,
+): Promise<string> {
+  const redis = await getRedis();
+  if (!redis) throw new Error("KV not configured");
+  const id = subscriptionId(sub);
+  const prefs = mergePrefs(prefsPartial);
+  const stored: StoredSubscription = {
+    id,
+    sub,
+    prefs,
+    savedAt: Date.now(),
+  };
+  await redis.set(`${SUB_PREFIX}${id}`, JSON.stringify(stored), {
+    ex: SUB_TTL_SECONDS,
+  });
+  await redis.sadd(SUBS_INDEX, id);
+  return id;
+}
+
+export async function getSubscription(
+  id: string,
+): Promise<StoredSubscription | null> {
+  const redis = await getRedis();
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(`${SUB_PREFIX}${id}`);
+    if (!raw) return null;
+    if (typeof raw === "string") return JSON.parse(raw) as StoredSubscription;
+    if (typeof raw === "object") return raw as StoredSubscription;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Updates only the prefs field on an existing subscription. The endpoint +
+ * keys are immutable across pref updates — riders edit their alert config
+ * without re-subscribing.
+ */
+export async function updatePrefs(
+  id: string,
+  prefsPartial: Partial<AlertPrefs>,
+): Promise<StoredSubscription | null> {
+  const existing = await getSubscription(id);
+  if (!existing) return null;
+  const prefs = mergePrefs({ ...existing.prefs, ...prefsPartial });
+  const next: StoredSubscription = { ...existing, prefs, savedAt: Date.now() };
+  const redis = await getRedis();
+  if (!redis) throw new Error("KV not configured");
+  await redis.set(`${SUB_PREFIX}${id}`, JSON.stringify(next), {
+    ex: SUB_TTL_SECONDS,
+  });
+  return next;
+}
+
+export async function removeSubscription(id: string): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) return;
+  await redis.del(`${SUB_PREFIX}${id}`);
+  await redis.srem(SUBS_INDEX, id);
+}
+
+/**
+ * Used by the dispatcher only. Returns every active subscription. Single-
+ * digit subscriber count expected for the foreseeable future; if this ever
+ * climbs past ~500 we'd batch + paginate instead of scanning the full set.
+ */
+export async function listSubscriptions(): Promise<StoredSubscription[]> {
+  const redis = await getRedis();
+  if (!redis) return [];
+  const ids = (await redis.smembers(SUBS_INDEX)) as string[];
+  if (ids.length === 0) return [];
+  const out: StoredSubscription[] = [];
+  for (const id of ids) {
+    const s = await getSubscription(id);
+    if (s) {
+      out.push(s);
+    } else {
+      // The TTL expired or the row was manually deleted — clean the index.
+      await redis.srem(SUBS_INDEX, id);
+    }
+  }
+  return out;
+}

--- a/lib/push/types.ts
+++ b/lib/push/types.ts
@@ -1,0 +1,40 @@
+// Pure types + defaults for the push pipeline. No node:* imports — this
+// file is safe for client bundles. Server-only code (KV ops, web-push
+// sending) lives in lib/push/store.ts and lib/push/dispatcher.ts.
+
+export type AlertTier = "all" | "alert_only";
+
+export type AlertPrefs = {
+  /**
+   * 'alert_only' (default) → only fire pushes for smokey + patrol + unknown
+   * (matches computeStatus() alert tiers). 'all' also fires for sar +
+   * transport so curious riders can hear about every wing in the air.
+   */
+  tier: AlertTier;
+  /**
+   * 'any' → push for any qualifying takeoff regardless of where it happens.
+   * Otherwise an array of hot-zone cell IDs the rider has opted into.
+   */
+  zones: string[] | "any";
+  /** Rider-local hour at which quiet hours START (24-hour, 0-23). */
+  quiet_start_h: number;
+  /** Rider-local hour at which quiet hours END (24-hour, 0-23). */
+  quiet_end_h: number;
+  /** IANA TZ name; rider browser supplies it via Intl.DateTimeFormat. */
+  tz: string;
+};
+
+export const DEFAULT_PREFS: AlertPrefs = {
+  tier: "alert_only",
+  zones: "any",
+  quiet_start_h: 23,
+  quiet_end_h: 6,
+  tz: "America/Los_Angeles",
+};
+
+export type StoredSubscription = {
+  id: string;
+  sub: PushSubscriptionJSON;
+  prefs: AlertPrefs;
+  savedAt: number;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,14 @@
         "react-markdown": "^10.1.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@types/node": "^20.16.13",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/web-push": "^3.6.4",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
@@ -1386,6 +1388,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -1443,6 +1455,15 @@
         }
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1470,6 +1491,18 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -1544,6 +1577,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1590,6 +1629,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1836,6 +1881,15 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.345",
@@ -2172,6 +2226,34 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -2317,6 +2399,27 @@
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
@@ -3267,6 +3370,12 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3986,6 +4095,32 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4481,6 +4616,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "react-markdown": "^10.1.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@types/node": "^20.16.13",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/web-push": "^3.6.4",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,38 @@
+// SmokySignal service worker. Web Push only — caching is out of scope here
+// (we lean on Vercel's edge cache for static assets). Keep this file tiny so
+// installed PWAs update fast.
+
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (_) {
+    payload = {};
+  }
+  const title = payload.title || "Smokey";
+  const options = {
+    body: payload.body || "",
+    icon: "/icons/icon-192.png",
+    badge: "/icons/favicon-96.png",
+    tag: payload.tag || "smokey",
+    renotify: false,
+    data: payload.data || {},
+    silent: payload.silent === true,
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || "/";
+  event.waitUntil(
+    clients.matchAll({ type: "window" }).then((wins) => {
+      const existing = wins.find((c) => c.url.endsWith(url));
+      if (existing) return existing.focus();
+      return clients.openWindow(url);
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

Complete VAPID-keyed Web Push pipeline. Two commits, intentionally split:

1. **Pipeline** — service worker, server-side dispatcher, KV-backed subscription store, four API routes, hookup in \`recordActivity\`.
2. **UI** — \`/settings/alerts\` page, dashboard inline opt-in card, IOSInstallPrompt copy tweak, admin broadcast-test button.

Builds clean. \`/api/push/{subscribe,unsubscribe,prefs,test}\` and \`/settings/alerts\` all show in the build manifest.

## Voice review (Part D of the spec)

Every notification + UI string, audited against \`design/BRAND.md\` §3:

| Check | Result |
|---|---|
| No emoji anywhere | ✓ |
| No exclamation marks | ✓ |
| Headlines 3–6 words | ✓ — actually 2–5 (\"Smokey's up.\" / \"Eyes up.\" / \"SAR run.\" / \"Transport up.\") |
| Body ≤ 140 chars | ✓ — \`trimBody()\` enforces |
| No forbidden vocab (police / cop / law enforcement / drone / surveilling / monitoring / brake / accelerate / safe / no danger) | ✓ |
| \"Smokey\" with E for bird/callsign, \"SmokySignal\" unchanged | ✓ |
| CB-slang garnish max once per surface | ✓ — \"Channel 19\" once on /settings/alerts, \"10-4\" once in the test payload |

Notification payload table:

| Role | Title | Body template |
|---|---|---|
| smokey | \`Smokey's up.\` | \`{name} watching. {alt}'.\` |
| patrol | \`Eyes up.\` | \`{name} airborne. {alt}'.\` |
| unknown | \`Eyes up.\` | \`Unidentified bird airborne. {alt}'.\` |
| sar | \`SAR run.\` | \`{name} on a rescue run.\` |
| transport | \`Transport up.\` | \`{name} airborne. {alt}'.\` |
| test | \`Smokey · test\` | \`Channel 19. Test ping. 10-4.\` |

UI copy table (every user-facing string on the new surfaces):

| Surface | String |
|---|---|
| /settings/alerts eyebrow | \`Alerts · Channel 19\` |
| /settings/alerts H1 | \`Get a ping when the bird's up.\` |
| Empty state (not subscribed) | \`Quiet skies. No alerts armed.\` |
| Subscribe toast | \`10-4. We'll keep you posted.\` |
| Unsubscribe toast | \`Off the air. Channel 19 still open if you change your mind.\` |
| Tier picker — alert only | \`Alert only\` / \`Bird up. Heads up.\` |
| Tier picker — all | \`All aircraft\` / \`Every wing in the air.\` |
| Quiet hours help | \`Channel 19 stays quiet between these hours.\` |
| Permission denied | \`Your browser blocked alerts. Open Safari → Settings → SmokySignal to fix.\` |
| iOS-not-PWA card | \`Alerts only work after you Add to Home Screen. Tap Share, then Add to Home Screen, then open the app icon.\` |
| Dashboard card eyebrow | \`OPT IN\` |
| Dashboard card title | \`Want a ping when Smokey's up?\` |
| Dashboard card subtitle | \`We'll only ping when an alert-class bird goes up. Tweak later in /settings/alerts.\` |
| Dashboard card armed | \`10-4. Alerts armed. Tweak in /settings/alerts.\` |
| IOSInstallPrompt mono | \`Add to Home Screen → Open SmokySignal → arm alerts.\` |
| Admin broadcast button | \`Broadcast test ping\` |

## Things that still need YOU before this can be tested end-to-end

- [ ] **VAPID keys live in Vercel** for Production + Preview + Development scopes. Confirm in Vercel dashboard. (Spec said \"1 2 done\" — assuming this is set there. The endpoints will return \`vapid_not_configured\` if any of the three are missing.)
- [ ] **Local \`.env.local\`** doesn't currently have the VAPID keys (\`grep -ic vapid .env.local → 0\`). Add them manually if you want to test in dev. Vercel preview will work as soon as keys are set there.
- [ ] **iOS PWA roundtrip** — the only test that proves real-world iOS push works:
  1. Open the Vercel preview on your phone in Safari
  2. Share → Add to Home Screen
  3. Open the app icon (NOT the Safari tab — must be standalone)
  4. \`/settings/alerts\` → Arm alerts → grant permission
  5. From your laptop, /admin → Push → Broadcast test ping
  6. Notification should arrive on phone
- [ ] **Edge case test:** subscribe on Chrome desktop, send broadcast test, then close all SmokySignal tabs. Send broadcast again — notification must arrive even with no tab open (proves the SW background path).
- [ ] **Dedupe smoke test:** trigger the same takeoff event twice within a minute (e.g., manually call \`dispatchTakeoff\` from a one-off script). Second call should return \`{ skipped: 0, reason: 'duplicate' }\`.

## Architecture notes

**Hookup point:** \`lib/activity.ts → recordActivity()\` lazy-imports the dispatcher and fires \`Promise.all\` over takeoff events. Failures swallowed per-event so the snapshot pipeline never breaks.

**Dedupe:** \`push:dispatched:{tail}:{takeoff_minute_ts}\` with 6h TTL. Minute precision so a 10s poll cadence can't fire two distinct dedupe keys for the same event.

**Quiet hours:** \`Intl.DateTimeFormat\` in the rider's TZ; supports wrap-around windows (e.g. 23 → 6). Falls back to UTC silently if TZ is malformed.

**Dead endpoints:** 410/404 from the push provider prunes the subscription from KV automatically. Other errors logged + skipped, dispatch continues.

**No PII stored:** subscription endpoint is a Push-service URL (already not personally identifying). The only rider-supplied field is timezone, used for quiet hours math. Documented in \`lib/push/store.ts\`.

## Out of scope (deferred)

- Per-zone opt-in UI — the data layer (\`zoneIdForPoint\`, \`prefs.zones\` array filtering) is wired; the UI section says \"Per-zone filters land once your local hot-zones have settled in.\"
- Background geolocation / smart muting — v2 native-shell concern.
- SMS fallback, multi-language, Apple Wallet — explicitly out of scope per spec.
- Web push on \`/radar\` while page is open — already covered by live SSE + the pulsing dot.

## Rollback

\`git revert <merge-commit>\` is safe. No schema changes (KV keys are namespaced under \`push:*\`, additive only). No env var deletions required. Existing subscriptions in KV stay until their 90-day TTL expires; they'll never be sent to since the SW + dispatcher are gone, and they'll silently fall off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)