### PR TITLE
chore(dev): scripted local env setup + boot env check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,62 @@
-# Upstash Redis (Vercel Marketplace integration auto-injects these in prod —
-# both Preview and Production envs). Optional locally; without them the app
-# falls back to an in-memory cache.
+# SmokySignal — local dev environment
+#
+# Quick setup on a fresh clone:
+#     npx vercel link            # one-time, pick the SmokySignal project
+#     npm run env:pull           # syncs Vercel Development env into .env.local
+#     npm run dev                # the predev hook checks for missing keys
+#
+# Keys below are grouped by what local dev actually needs.
+
+# ───── REQUIRED for local dev ─────────────────────────────────────────
+# Without these, `npm run dev` aborts in the predev env check.
+
+# MapTiler tiles. Public-by-design (NEXT_PUBLIC_*) so it's safe in the
+# client bundle. If your MapTiler key is domain-restricted in the
+# MapTiler dashboard, add http://localhost:3000 to its allowed origins
+# or generate a separate dev key.
+NEXT_PUBLIC_MAPTILER_KEY=
+
+# ───── OPTIONAL locally — fallbacks exist ─────────────────────────────
+# Without these, dev still runs but features degrade as noted.
+
+# Upstash Redis (Vercel Marketplace integration auto-injects in prod).
+# Local fallback: in-memory cache. Fine for UI work; nothing persists
+# across dev-server restarts.
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
 
-# Admin tail editor — milestone 2. Leave blank locally; set in Vercel for prod.
-ADMIN_PASSCODE=
-
-# MapTiler — milestone 3 (Radar map). Leave blank until then.
-NEXT_PUBLIC_MAPTILER_KEY=
-
-# OpenSky Network OAuth2 client_credentials (added March 2025; basic auth
-# is deprecated). When unset, fetchOpenSky() falls back to anonymous
-# requests (heavily rate-limited; useful for dev only).
+# OpenSky OAuth2 client_credentials. Local fallback: anonymous tier
+# (heavily rate-limited; usable for spot checks, not real testing).
 OPENSKY_CLIENT_ID=
 OPENSKY_CLIENT_SECRET=
 
-# Optional: bbox for the regional ADS-B query (Puget Sound)
+# Admin tail editor. Set if you're testing /admin locally; otherwise
+# /admin will refuse access.
+ADMIN_PASSCODE=
+
+# Region bbox for the regional ADS-B query (Puget Sound default).
 SS_REGION_LAT=47.6
 SS_REGION_LON=-122.3
 SS_REGION_NM=80
 
-# CRON_SECRET protects /api/cron/* — Vercel cron sends a Bearer header.
-# Generate with: openssl rand -hex 32
+# Public canonical URL — used by /api/badge.svg + OG metadata. Defaults
+# to https://www.smokysignal.app on the Production scope; local dev
+# usually doesn't need it.
+NEXT_PUBLIC_BASE_URL=
+
+# ───── DEPLOY-ONLY — do not bother setting locally ────────────────────
+# These exist on Vercel but `npm run dev` ignores them. Listed here so
+# nobody hits a "where do I set this?" question. Real values live in
+# Vercel Settings → Environment Variables.
+
+# Vercel Cron auth. Vercel sends `Authorization: Bearer ${CRON_SECRET}`
+# to /api/cron/*. Generate with: openssl rand -hex 32
 CRON_SECRET=
 
 # Web Push (VAPID). Generate with: npx web-push generate-vapid-keys
-# NEXT_PUBLIC_VAPID_PUBLIC_KEY is shipped to the browser; the private key
-# stays server-only. VAPID_SUBJECT is the contact mailto a push provider
-# uses to reach us about subscription issues.
+# NEXT_PUBLIC_VAPID_PUBLIC_KEY is browser-side; the private key stays
+# server-only. VAPID_SUBJECT is the contact mailto a push provider uses
+# to reach us about subscription issues.
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:adavenport321@gmail.com

--- a/HOW_TO_HAND_OFF.md
+++ b/HOW_TO_HAND_OFF.md
@@ -49,6 +49,24 @@ smokysignal-app/
 
 ---
 
+## 2.5. First-time local dev setup
+
+Once the repo is cloned (or after a fresh `git pull` onto a new machine):
+
+```bash
+cd ~/Dev/SmokySignal
+npm install
+npx vercel link            # one-time. Pick the SmokySignal project.
+npm run env:pull           # populates .env.local from Vercel Development scope.
+npm run dev                # predev hook checks for missing keys.
+```
+
+If `npm run dev` aborts with a missing-env error, follow its instructions — usually it just means re-running `npm run env:pull` after Vercel got new env vars. If `npx vercel` itself errors with "token provided via VERCEL_TOKEN environment variable is not valid," your shell has a stale token set; `unset VERCEL_TOKEN` and try again.
+
+**MapTiler note.** If `npm run dev` boots but the radar map shows blank tiles, your MapTiler key may be domain-restricted to production hosts. Open https://cloud.maptiler.com/account/keys/, edit the key, and add `http://localhost:3000` (or `*` for any localhost port) to the allowed origins. Or generate a separate unrestricted dev key and put it in `.env.local` only.
+
+---
+
 ## 3. Open Claude Code in that repo
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Open `design/SmokySignal.html` in any modern browser. Use the **Tweaks** toggle 
 
 ---
 
+## Running locally
+
+```bash
+npm install
+npx vercel link
+npm run env:pull
+npm run dev
+```
+
+Full setup: see `HOW_TO_HAND_OFF.md` §2.5.
+
+---
+
 ## Fidelity
 
 **High-fidelity** for visuals, layout, copy, and interaction logic. Final colors, typography, spacing, component composition, and state behavior are all locked. Pixel-match the designs.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/check-env.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/check-env.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "env:pull": "vercel env pull .env.local --environment=development --yes",
     "backfill": "tsx --env-file=.env.local scripts/backfill.ts",
     "backfill:dry": "tsx --env-file=.env.local scripts/backfill.ts --dry",
     "backfill:resume": "tsx --env-file=.env.local scripts/backfill.ts --resume --yes"

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Boot-time env check. Runs before `npm run dev` and `npm run build`.
+// Reads .env.local (if present) and complains about missing keys that
+// matter for local dev. Stays silent when everything is fine.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(new URL(".", import.meta.url).pathname, "..");
+const ENV_LOCAL = path.join(REPO_ROOT, ".env.local");
+
+// Keys we WARN about (dev/build still proceeds — fallbacks exist).
+const WARN = [
+  [
+    "KV_REST_API_URL",
+    "Without it: in-memory cache fallback. Fine for UI work; track-history persistence won't survive a dev-server restart.",
+  ],
+  ["KV_REST_API_TOKEN", "Without it: in-memory cache fallback."],
+  [
+    "OPENSKY_CLIENT_ID",
+    "Without it: anonymous OpenSky fallback (heavily rate-limited).",
+  ],
+  ["OPENSKY_CLIENT_SECRET", "Without it: anonymous OpenSky fallback."],
+];
+
+// Keys we BLOCK on (dev/build aborts with a clear error).
+const BLOCK = [
+  [
+    "NEXT_PUBLIC_MAPTILER_KEY",
+    "Required for the radar map to render. Run `npm run env:pull`.",
+  ],
+];
+
+function readEnvFile(p) {
+  try {
+    const text = fs.readFileSync(p, "utf8");
+    const out = {};
+    for (const line of text.split("\n")) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m) out[m[1]] = m[2];
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+const env = readEnvFile(ENV_LOCAL);
+
+if (!env) {
+  console.error(
+    [
+      "",
+      "─── SmokySignal: .env.local missing ─────────────────────────────",
+      "",
+      "Local dev needs an .env.local file. Quick fix:",
+      "",
+      "    npm run env:pull",
+      "",
+      "That syncs every env var from Vercel's Development scope into",
+      ".env.local (gitignored). One-time setup; rerun whenever Vercel",
+      "env vars change.",
+      "",
+      "Prerequisite: `npx vercel link` against the SmokySignal project.",
+      "─────────────────────────────────────────────────────────────────",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+const missingBlocking = BLOCK.filter(([k]) => !env[k] || env[k].trim() === "");
+const missingWarn = WARN.filter(([k]) => !env[k] || env[k].trim() === "");
+
+// Detect the "Vercel pulled OIDC only" failure mode: .env.local exists but
+// is essentially empty (only has VERCEL_OIDC_TOKEN or similar auto-injected
+// keys). This means env:pull ran but Development scope has nothing of
+// substance ticked.
+const meaningfulKeys = Object.keys(env).filter(
+  (k) =>
+    !["VERCEL_OIDC_TOKEN", "VERCEL", "VERCEL_ENV"].includes(k) &&
+    !k.startsWith("VERCEL_"),
+);
+const looksUnpopulated = meaningfulKeys.length === 0;
+
+if (missingBlocking.length) {
+  console.error("");
+  console.error(
+    "─── SmokySignal: missing required env vars ────────────────────",
+  );
+  console.error("");
+  for (const [k, why] of missingBlocking) {
+    console.error(`    ${k}`);
+    console.error(`        ${why}`);
+    console.error("");
+  }
+  if (looksUnpopulated) {
+    console.error("Detected: .env.local has only Vercel auto-injected keys.");
+    console.error(
+      "Your Vercel project likely has these env vars set for",
+    );
+    console.error("Production/Preview but not Development.");
+    console.error("");
+    console.error("Fix:");
+    console.error(
+      "  1. Open Vercel → your project → Settings → Environment Variables",
+    );
+    console.error("  2. For each missing key above, click the row, tick the");
+    console.error('     "Development" checkbox, save.');
+    console.error(
+      "  3. Skip KV_REST_API_* — those are integration-managed.",
+    );
+    console.error("  4. Re-run `npm run env:pull` and `npm run dev`.");
+  } else {
+    console.error("Fix: `npm run env:pull` (or edit .env.local manually).");
+  }
+  console.error(
+    "───────────────────────────────────────────────────────────────",
+  );
+  console.error("");
+  process.exit(1);
+}
+
+if (missingWarn.length && !process.env.SS_QUIET_ENV_CHECK) {
+  console.warn("");
+  console.warn("SmokySignal: optional env vars missing — using fallbacks:");
+  for (const [k, why] of missingWarn) console.warn(`    ${k} — ${why}`);
+  console.warn("Set SS_QUIET_ENV_CHECK=1 to silence this warning.");
+  console.warn("");
+}


### PR DESCRIPTION
## Summary

Scripted local dev setup. After merge, a fresh clone goes from \`git clone\` to a working dev server in 4 commands instead of silently rendering a missing-key placeholder where the map should be.

## Verification (done locally)

- \`npm run dev\` aborts cleanly when \`.env.local\` is missing — exit 1, full instructions printed.
- \`npm run dev\` aborts cleanly when \`.env.local\` exists but \`NEXT_PUBLIC_MAPTILER_KEY\` is empty — exit 1, single-key callout.
- \`npm run env:pull\` populates \`.env.local\` from Vercel Development scope. Verified pulling 5 keys (CRON_SECRET, NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_MAPTILER_KEY, OPENSKY_CLIENT_ID/SECRET) plus the auto-populated KV + OIDC vars.
- After \`env:pull\`, the boot check passes silently and dev server boots in ~2.3s.
- Optional-fallback warnings render only when relevant (e.g., remove KV vars → warning prints; dev still boots).

## One thing this PR can't fix on its own

The MapTiler key Vercel hands out is **domain-restricted to production hosts** — \`localhost:3000\` gets a 403 from \`api.maptiler.com\`. So after this PR merges, you still need to do one of:

1. Open https://cloud.maptiler.com/account/keys/, edit the key in use, add \`http://localhost:3000\` (or \`*\` for any localhost) to allowed origins. Quickest, but loosens prod key.
2. Generate a separate unrestricted dev key, put it in \`.env.local\` only, and don't propagate to Vercel.

The PR documents both options in \`.env.example\` and \`HOW_TO_HAND_OFF.md\` §2.5. Once the MapTiler key accepts localhost, every map-related visual check works locally.

## Aside, worth flagging for the next push-related PR

\`vercel env ls\` shows VAPID keys + ADMIN_PASSCODE are in Production + Preview but **not Development** scope. So local push subscribe and local /admin will still hit fallbacks even after \`env:pull\`. Not blocking this PR, but worth ticking the Development checkbox in the Vercel dashboard for those three before the next iteration on PR #4.

## Follow-up after merge

1. Run \`npm run env:pull\` once on the Mac Mini.
2. Update MapTiler dashboard to allow localhost (or generate a separate dev key).
3. Re-run \`npm run dev\` — map should render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)