### PR TITLE
feat(learning): "Learning your sky" empty state across surfaces

### DIFF
--- a/app/(tabs)/forecast/page.tsx
+++ b/app/(tabs)/forecast/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { SS_TOKENS } from "@/lib/tokens";
 import { getForecastGrid } from "@/lib/predictor";
 import { ForecastGridView } from "@/components/ForecastGridView";
+import { LearningPanel } from "@/components/LearningPanel";
+import { getLearningState } from "@/lib/learning";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -9,8 +11,16 @@ export const metadata = {
   description: "Weekly probability of fleet takeoffs by hour and day.",
 };
 
+const FORECAST_LEARNING_EVENT_FLOOR = 30;
+
 export default async function ForecastPage() {
-  const grid = await getForecastGrid();
+  const [grid, learning] = await Promise.all([
+    getForecastGrid(),
+    getLearningState(),
+  ]);
+  const showLearning =
+    learning.stillLearning ||
+    grid.total_events < FORECAST_LEARNING_EVENT_FLOOR;
   return (
     <main
       style={{
@@ -63,12 +73,20 @@ export default async function ForecastPage() {
             margin: 0,
           }}
         >
-          Probability of any fleet takeoff by hour-of-week, derived from{" "}
-          {grid.total_events} historical takeoff event
-          {grid.total_events === 1 ? "" : "s"}. Brighter cells = more
-          likely. Tap a cell to see the most common tails.
+          Hour-of-week probability of any fleet takeoff, drawn from{" "}
+          <span className="ss-mono">{grid.total_events}</span> logged
+          takeoff{grid.total_events === 1 ? "" : "s"}. Brighter cells,
+          busier hour. Tap a cell to see the regular birds.
         </p>
       </section>
+
+      {showLearning && (
+        <LearningPanel
+          state={learning}
+          eventsSeen={grid.total_events}
+          variant="banner"
+        />
+      )}
 
       <ForecastGridView grid={grid} />
     </main>

--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -2,6 +2,7 @@ import { Glanceable } from "@/components/Glanceable";
 import { getSnapshot } from "@/lib/snapshot";
 import { mockAirborneSnapshot } from "@/lib/mock";
 import { getRecentActivity } from "@/lib/activity";
+import { getLearningState } from "@/lib/learning";
 
 export const dynamic = "force-dynamic";
 
@@ -12,9 +13,10 @@ export default async function Page({
 }: {
   searchParams: SP;
 }) {
-  const [real, activity] = await Promise.all([
+  const [real, activity, learning] = await Promise.all([
     getSnapshot(),
     getRecentActivity(1),
+    getLearningState(),
   ]);
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
@@ -23,6 +25,7 @@ export default async function Page({
       initial={initial}
       mockOn={mockOn}
       initialActivity={activity}
+      learning={learning}
     />
   );
 }

--- a/app/(tabs)/radar/page.tsx
+++ b/app/(tabs)/radar/page.tsx
@@ -1,6 +1,7 @@
 import { RadarShell } from "@/components/RadarShell";
 import { getSnapshot } from "@/lib/snapshot";
 import { mockAirborneSnapshot } from "@/lib/mock";
+import { getLearningState } from "@/lib/learning";
 
 export const metadata = {
   title: "Radar",
@@ -15,8 +16,11 @@ export default async function RadarPage({
 }: {
   searchParams: SP;
 }) {
-  const real = await getSnapshot();
+  const [real, learning] = await Promise.all([
+    getSnapshot(),
+    getLearningState(),
+  ]);
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
-  return <RadarShell initial={initial} mockOn={mockOn} />;
+  return <RadarShell initial={initial} mockOn={mockOn} learning={learning} />;
 }

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
 import type { ActivityEntry } from "@/lib/activity";
+import type { LearningState } from "@/lib/learning";
 import { SS_TOKENS } from "@/lib/tokens";
 import { fmtAloft } from "@/lib/format";
 import { useAircraft } from "@/lib/hooks/useAircraft";
@@ -25,12 +26,14 @@ type Props = {
   initial: Snapshot;
   mockOn?: boolean;
   initialActivity?: ActivityEntry[];
+  learning?: LearningState;
 };
 
 export function Glanceable({
   initial,
   mockOn = false,
   initialActivity = [],
+  learning,
 }: Props) {
   const snap = useAircraft(initial, mockOn);
   const [updatedAgo, setUpdatedAgo] = useState<number>(0);
@@ -173,7 +176,7 @@ export function Glanceable({
 
       {others.length > 0 && <Others others={others} />}
 
-      <PredictionCard />
+      <PredictionCard learning={learning} />
 
       <Footer />
     </main>

--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -13,7 +13,9 @@ import { useEffect, useRef, useState } from "react";
 import type { Map as MaplibreMap, GeoJSONSource } from "maplibre-gl";
 import { SS_TOKENS } from "@/lib/tokens";
 import type { HotZone } from "@/lib/hotzones";
+import type { LearningState } from "@/lib/learning";
 import { Tooltip } from "./Tooltip";
+import { LearningPanel } from "./LearningPanel";
 
 const VISIBLE_KEY = "ss_hotzones_visible";
 const FILTER_KEY = "ss_hotzones_filter";
@@ -82,9 +84,10 @@ type Props = {
   map: MaplibreMap | null;
   /** Extra px above the tab bar — pass when the airborne carousel is on. */
   bottomBoost?: number;
+  learning?: LearningState;
 };
 
-export function HotZoneLayer({ map, bottomBoost = 0 }: Props) {
+export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
   const [enabled, setEnabled] = useState<boolean>(true);
   const [filter, setFilter] = useState<Filter>(DEFAULT_FILTER);
   const [zones, setZones] = useState<HotZone[] | null>(null);
@@ -292,8 +295,57 @@ export function HotZoneLayer({ map, bottomBoost = 0 }: Props) {
 
   const bottom = TABBAR_HEIGHT + 16 + bottomBoost;
 
+  // Empty-state messaging: only show once we know zones returned empty AND
+  // the toggle is on (otherwise the user explicitly hid them). Sits just
+  // above the toggle row so it doesn't fight the map.
+  const showEmptyState = enabled && zones !== null && zones.length === 0;
+  const emptyVariant: "learning" | "filter" = learning?.stillLearning
+    ? "learning"
+    : "filter";
+
   return (
     <>
+      {showEmptyState && emptyVariant === "learning" && learning && (
+        <LearningPanel
+          state={learning}
+          zonesLearned={0}
+          variant="overlay"
+          style={{
+            position: "absolute",
+            left: 12,
+            right: 12,
+            bottom: bottom + 56,
+            zIndex: 11,
+            maxWidth: 380,
+            margin: "0 auto",
+          }}
+        />
+      )}
+      {showEmptyState && emptyVariant === "filter" && (
+        <div
+          className="ss-mono"
+          style={{
+            position: "absolute",
+            left: 12,
+            right: 12,
+            bottom: bottom + 56,
+            zIndex: 11,
+            maxWidth: 380,
+            margin: "0 auto",
+            padding: "10px 14px",
+            borderRadius: 12,
+            background: "rgba(11,13,16,0.92)",
+            border: `.5px solid ${SS_TOKENS.hairline2}`,
+            backdropFilter: "blur(10px)",
+            WebkitBackdropFilter: "blur(10px)",
+            color: SS_TOKENS.fg1,
+            fontSize: 11,
+            letterSpacing: ".04em",
+          }}
+        >
+          No hot zones in your filter — try widening the operator or region.
+        </div>
+      )}
       <div
         style={{
           position: "absolute",

--- a/components/LearningPanel.tsx
+++ b/components/LearningPanel.tsx
@@ -1,0 +1,216 @@
+// Canonical "Learning your sky" panel — three variants of the same
+// content. Used wherever a surface depends on hot-zone or forecast data
+// that's still being collected. Single component so the copy + day
+// counter never disagree across home, radar, and forecast.
+//
+// Voice rules baked in (design/BRAND.md §3):
+//  - No emoji, no exclamation marks.
+//  - Mono on every numeric (day count, events seen, days remaining).
+//  - "Channel 19" garnish appears at most once across the page.
+//  - Copy is "you'll wait days," never "loading."
+
+import { LEARNING_THRESHOLD_DAYS, type LearningState } from "@/lib/learning";
+import { SS_TOKENS } from "@/lib/tokens";
+
+type Variant = "card" | "banner" | "overlay";
+
+type Props = {
+  state: LearningState;
+  /** Hot-zones surface: how many zones have been learned so far. */
+  zonesLearned?: number;
+  /** Prediction card / forecast: total takeoff events seen. */
+  eventsSeen?: number;
+  variant?: Variant;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export function LearningPanel({
+  state,
+  zonesLearned,
+  eventsSeen,
+  variant = "card",
+  className,
+  style,
+}: Props) {
+  const headline = computeHeadline(state);
+  const body = computeBody(state, eventsSeen, zonesLearned);
+  const day = state.daysElapsed;
+  const cap = LEARNING_THRESHOLD_DAYS;
+  const eyebrow = state.stillLearning
+    ? `LEARNING YOUR SKY · DAY ${day} OF ${cap}`
+    : `LEARNING YOUR SKY · ${cap}+ DAYS IN`;
+
+  if (variant === "banner") {
+    return (
+      <div
+        className={className}
+        style={{
+          background: SS_TOKENS.bg1,
+          border: `.5px solid ${SS_TOKENS.hairline}`,
+          borderRadius: 12,
+          padding: "10px 14px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+          ...style,
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>
+          <span
+            className="ss-mono"
+            style={{ fontSize: 9.5, letterSpacing: ".1em", color: SS_TOKENS.fg2 }}
+          >
+            {eyebrow}
+          </span>
+          <span
+            className="ss-mono"
+            style={{ fontSize: 10.5, color: SS_TOKENS.fg1 }}
+          >
+            {progressLabel(state)}
+          </span>
+        </div>
+        <ProgressBar progress={state.progress} />
+        <p style={{ fontSize: 12, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.45 }}>
+          {body}
+        </p>
+      </div>
+    );
+  }
+
+  const cardInner = (
+    <>
+      <div
+        className="ss-mono"
+        style={{
+          fontSize: 9.5,
+          letterSpacing: ".1em",
+          color: SS_TOKENS.fg2,
+          marginBottom: 8,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <h3
+        style={{
+          fontSize: 16,
+          fontWeight: 700,
+          color: SS_TOKENS.fg0,
+          letterSpacing: "-.01em",
+          margin: 0,
+          marginBottom: 8,
+        }}
+      >
+        {headline}
+      </h3>
+      <ProgressBar progress={state.progress} />
+      <p
+        style={{
+          fontSize: 13,
+          color: SS_TOKENS.fg1,
+          margin: 0,
+          marginTop: 10,
+          lineHeight: 1.5,
+        }}
+      >
+        {body}
+      </p>
+    </>
+  );
+
+  if (variant === "overlay") {
+    return (
+      <div
+        className={className}
+        style={{
+          background: "rgba(11,13,16,0.92)",
+          border: `.5px solid ${SS_TOKENS.hairline2}`,
+          borderRadius: 14,
+          padding: "14px 16px",
+          backdropFilter: "blur(10px)",
+          WebkitBackdropFilter: "blur(10px)",
+          ...style,
+        }}
+      >
+        {cardInner}
+      </div>
+    );
+  }
+
+  // card (default)
+  return (
+    <section
+      className={className}
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 14,
+        padding: "14px 16px",
+        ...style,
+      }}
+    >
+      {cardInner}
+    </section>
+  );
+}
+
+function ProgressBar({ progress }: { progress: number }) {
+  const clamped = Math.max(0, Math.min(1, progress));
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={LEARNING_THRESHOLD_DAYS}
+      aria-valuenow={Math.round(clamped * LEARNING_THRESHOLD_DAYS)}
+      style={{
+        width: "100%",
+        height: 2,
+        background: SS_TOKENS.hairline,
+        borderRadius: 1,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          width: `${(clamped * 100).toFixed(2)}%`,
+          height: "100%",
+          background: SS_TOKENS.alert,
+        }}
+      />
+    </div>
+  );
+}
+
+function computeHeadline(state: LearningState): string {
+  if (state.stillLearning) return "Channel 19's tuning in.";
+  return "Sky's quiet enough to count.";
+}
+
+function computeBody(
+  state: LearningState,
+  eventsSeen?: number,
+  zonesLearned?: number,
+): string {
+  const events = eventsSeen ?? 0;
+  const zones = zonesLearned ?? 0;
+  if (state.daysElapsed < 7) {
+    return `We just got our ears on. Forecasts and hot zones come online once we've watched the sky for ${LEARNING_THRESHOLD_DAYS} days.`;
+  }
+  if (state.stillLearning) {
+    const d = state.daysRemaining;
+    const dayWord = d === 1 ? "day" : "days";
+    return `${d} ${dayWord} of listening to go before forecasts get sharp. Hot zones need a month of patrols to settle.`;
+  }
+  // past threshold but data sparse
+  if (zonesLearned !== undefined && zones > 0) {
+    return `${zones} zones learned so far. Sky's been quieter than expected — give it another week and the patterns sharpen.`;
+  }
+  return `${events} takeoffs logged. Sky's been quieter than expected — give it another week and the patterns surface.`;
+}
+
+function progressLabel(state: LearningState): string {
+  if (state.stillLearning) {
+    return `${state.daysElapsed}/${LEARNING_THRESHOLD_DAYS} days`;
+  }
+  return `${LEARNING_THRESHOLD_DAYS}+ days`;
+}

--- a/components/PredictionCard.tsx
+++ b/components/PredictionCard.tsx
@@ -1,18 +1,29 @@
 "use client";
 
 // Reads /api/predict on mount and renders the top likely-sweep window
-// derived from accumulated activity events. Falls back to a "still
-// learning" card when sample size is too small or the cache is empty.
+// derived from accumulated activity events. Renders the canonical
+// LearningPanel whenever we're inside the 30-day learning window OR
+// the predictor returned too few events for a useful forecast.
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Card } from "./Card";
+import { LearningPanel } from "./LearningPanel";
 import { SS_TOKENS } from "@/lib/tokens";
 import type { PredictorOutput, PredictionWindow } from "@/lib/predictor";
+import { LEARNING_THRESHOLD_DAYS, type LearningState } from "@/lib/learning";
 
 const MIN_TOTAL_EVENTS_FOR_PREDICTION = 10;
 
-export function PredictionCard() {
+const FALLBACK_LEARNING: LearningState = {
+  firstSampleIso: null,
+  daysElapsed: 0,
+  daysRemaining: LEARNING_THRESHOLD_DAYS,
+  progress: 0,
+  stillLearning: true,
+};
+
+export function PredictionCard({ learning }: { learning?: LearningState }) {
   const [data, setData] = useState<PredictorOutput | null>(null);
 
   useEffect(() => {
@@ -38,7 +49,18 @@ export function PredictionCard() {
 
   const tooFew = data.total_events < MIN_TOTAL_EVENTS_FOR_PREDICTION;
   const top = data.windows[0];
-  if (tooFew || !top) return <Learning total={data.total_events} />;
+  // Show the learning panel whenever we're inside the 30-day window OR
+  // the predictor doesn't have enough data yet. Past the threshold + with
+  // enough events, the regular forecast card takes over.
+  if (learning?.stillLearning || tooFew || !top) {
+    return (
+      <LearningPanel
+        state={learning ?? FALLBACK_LEARNING}
+        eventsSeen={data.total_events}
+        variant="card"
+      />
+    );
+  }
 
   return (
     <Card>
@@ -127,23 +149,6 @@ export function PredictionCard() {
         >
           View weekly forecast →
         </Link>
-      </div>
-    </Card>
-  );
-}
-
-function Learning({ total }: { total: number }) {
-  return (
-    <Card>
-      <div className="ss-eyebrow" style={{ marginBottom: 6 }}>
-        Still learning
-      </div>
-      <div
-        style={{ fontSize: 14, color: SS_TOKENS.fg1, lineHeight: 1.45 }}
-      >
-        We&rsquo;ve seen {total} takeoff
-        {total === 1 ? "" : "s"} so far. Predictions appear once we have
-        more historical data to draw on.
       </div>
     </Card>
   );

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -13,6 +13,7 @@ import { HotZoneLayer } from "./HotZoneLayer";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
+import type { LearningState } from "@/lib/learning";
 
 export type RiderPos = { lat: number; lon: number };
 
@@ -31,9 +32,13 @@ const RadarMap = nextDynamic(() => import("./RadarMap"), {
 
 const TABBAR_HEIGHT = 66;
 
-type Props = { initial: Snapshot; mockOn?: boolean };
+type Props = {
+  initial: Snapshot;
+  mockOn?: boolean;
+  learning?: LearningState;
+};
 
-export function RadarShell({ initial, mockOn = false }: Props) {
+export function RadarShell({ initial, mockOn = false, learning }: Props) {
   const snap = useAircraft(initial, mockOn);
   const fleetMap = useMemo(
     () => new Map<string, FleetEntry>(snap.aircraft.map((a) => [a.tail, a])),
@@ -87,6 +92,7 @@ export function RadarShell({ initial, mockOn = false }: Props) {
       <HotZoneLayer
         map={map}
         bottomBoost={airborne.length > 0 ? 130 : 0}
+        learning={learning}
       />
       <HelpIcon />
 

--- a/content/help.md
+++ b/content/help.md
@@ -88,6 +88,18 @@ The map shows the in-progress flight if the plane is currently up (with a pulsin
 
 `/forecast` shows a 7×24 grid: probability of any fleet takeoff per hour-of-week. Brighter cells = more historical activity. The current Pacific (day, hour) is outlined in amber. Tap any cell to see which tails most commonly fly in that bucket.
 
+## Why is it still learning?
+
+You'll see a "Learning your sky" panel on the home, radar, or forecast screens until SmokySignal has watched the sky for a full 30 days. We track the start of that window from the first ADS-B sample we ingested — not from when you opened the app — so the timer ticks for everyone in sync.
+
+A month is the floor for these features to mean something:
+
+- **Hot zones** need at least four weekend cycles of patrols before the heatmap settles. Two flights over the same county look like a hot zone after a week and like noise after a month.
+- **The forecast grid** needs roughly one observation per hour-of-week before any cell's probability stops jumping around. That's 168 buckets to fill from a fleet of 16 tails.
+- **The home prediction card** holds back its "next likely sweep" line until both the day count clears and we've logged enough takeoffs to call a pattern (10+).
+
+The counter on the panel shows where we are in the 30-day window. Past day 30, the panels switch to "30+ days in" and the data-driven cards take over. If a panel still appears past day 30, it means we've crossed the time threshold but the data is still sparse — usually because the sky's been quieter than expected. Give it another week.
+
 ## Public flight share pages
 
 Every flight gets a permanent shareable URL: `/flight/{TAIL}/{FLIGHT_ID}`. You can grab it via the **Share** button next to the back link on any plane detail page (and on the admin recent-flights view). The link works without auth and includes a social-friendly preview image.
@@ -110,7 +122,7 @@ Your screen wake-lock preference and hot-zone filter live in your phone's local 
 
 ## Troubleshooting
 
-- **The hot-zones heatmap is empty.** It depends on accumulated track data and refreshes daily. After a fresh deploy or if you're filtering to a specific tail with little history, the layer may legitimately have nothing to render.
+- **The hot-zones heatmap is empty.** Either we're inside the 30-day learning window (see "Why is it still learning?" above), or your filter is narrow enough that nothing matches — try widening the operator or region.
 - **The map shows "MapTiler key missing."** The deployment is missing its `NEXT_PUBLIC_MAPTILER_KEY` environment variable. The app still works, but maps won't render.
 - **"Couldn't get a fix" when tapping Spotted.** Your browser's location permission is denied or your GPS is having a moment. Allow location access for `smokysignal.app` in browser settings.
 - **The activity feed is empty.** Either no fleet member has had a state change recently, or — if it's been many hours — the cron job that refreshes the snapshot may be on its daily schedule. Activity events fire once per snapshot refresh.

--- a/lib/learning.ts
+++ b/lib/learning.ts
@@ -1,0 +1,121 @@
+// Single source of truth for "how long has SmokySignal been listening to
+// the sky?" Hot zones, takeoff forecasts, and the home prediction card all
+// read from getLearningState() so the "Learning your sky" panel says the
+// same thing wherever it appears.
+//
+// The contract:
+//   - meta:first_sample_ts is written ONCE on the first successful track
+//     ingest after this code ships (logTracks calls
+//     recordFirstSampleIfMissing). After that the timer ticks on its own.
+//   - For repos with weeks of history already, run
+//     scripts/backfill-first-sample.ts once to seed the key from the
+//     oldest existing tracks:* entry. Without that, the production timer
+//     starts at deploy day and riders see "Learning your sky" even though
+//     we've been collecting data for weeks.
+
+import { cacheGet, cacheSet, getRedis } from "./cache";
+
+export const LEARNING_THRESHOLD_DAYS = 30;
+
+const META_KEY = "meta:first_sample_ts";
+const READ_CACHE_KEY = "ss:learning-state:v1";
+const READ_CACHE_TTL_SECONDS = 5 * 60;
+
+export type LearningState = {
+  /** ISO timestamp of the first sample ever ingested. null = nothing seen yet. */
+  firstSampleIso: string | null;
+  /** Whole days elapsed since firstSampleIso, capped at LEARNING_THRESHOLD_DAYS. */
+  daysElapsed: number;
+  /** Whole days remaining to reach LEARNING_THRESHOLD_DAYS. 0 once we cross the line. */
+  daysRemaining: number;
+  /** 0..1 fraction of the learning window completed. */
+  progress: number;
+  /** True until daysElapsed >= LEARNING_THRESHOLD_DAYS. */
+  stillLearning: boolean;
+};
+
+const MS_PER_DAY = 86_400_000;
+
+/** Pure derivation, exported for tests + tooling. */
+export function deriveLearningState(
+  firstSampleIso: string | null,
+  now: Date = new Date(),
+): LearningState {
+  if (!firstSampleIso) {
+    return {
+      firstSampleIso: null,
+      daysElapsed: 0,
+      daysRemaining: LEARNING_THRESHOLD_DAYS,
+      progress: 0,
+      stillLearning: true,
+    };
+  }
+  const start = Date.parse(firstSampleIso);
+  if (!Number.isFinite(start)) {
+    return {
+      firstSampleIso,
+      daysElapsed: 0,
+      daysRemaining: LEARNING_THRESHOLD_DAYS,
+      progress: 0,
+      stillLearning: true,
+    };
+  }
+  const rawDays = Math.max(0, Math.floor((now.getTime() - start) / MS_PER_DAY));
+  const daysElapsed = Math.min(rawDays, LEARNING_THRESHOLD_DAYS);
+  const daysRemaining = Math.max(0, LEARNING_THRESHOLD_DAYS - daysElapsed);
+  const progress = daysElapsed / LEARNING_THRESHOLD_DAYS;
+  return {
+    firstSampleIso,
+    daysElapsed,
+    daysRemaining,
+    progress,
+    stillLearning: daysElapsed < LEARNING_THRESHOLD_DAYS,
+  };
+}
+
+export async function getLearningState(): Promise<LearningState> {
+  const cached = await cacheGet<LearningState>(READ_CACHE_KEY);
+  if (cached) return cached;
+
+  const redis = await getRedis();
+  let firstSampleIso: string | null = null;
+  if (redis) {
+    try {
+      const raw = await redis.get(META_KEY);
+      if (typeof raw === "string" && raw.length > 0) {
+        firstSampleIso = raw;
+      }
+    } catch {
+      /* fall through with null */
+    }
+  }
+  const state = deriveLearningState(firstSampleIso);
+  await cacheSet(READ_CACHE_KEY, state, READ_CACHE_TTL_SECONDS);
+  return state;
+}
+
+/**
+ * Idempotent — sets meta:first_sample_ts iff missing. Called from logTracks
+ * on every snapshot regen so the very first successful track-write seeds
+ * the timer. After that this is a cheap NX no-op (one round-trip, no
+ * payload).
+ */
+export async function recordFirstSampleIfMissing(now: Date = new Date()): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) return;
+  try {
+    // Upstash Redis client supports SET with `nx: true` — only writes if
+    // the key doesn't exist. No payload guard needed; the call is cheap.
+    await redis.set(META_KEY, now.toISOString(), { nx: true });
+  } catch {
+    /* best-effort — non-fatal */
+  }
+}
+
+/** Test/operator helper: force a value (e.g. from the backfill script). */
+export async function setFirstSampleTs(iso: string): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) throw new Error("KV not configured");
+  await redis.set(META_KEY, iso);
+  await cacheSet(READ_CACHE_KEY, deriveLearningState(iso), READ_CACHE_TTL_SECONDS);
+}

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -9,6 +9,7 @@
 // Each daily key gets a 35-day TTL so the rolling window auto-cleans.
 
 import { getRedis } from "./cache";
+import { recordFirstSampleIfMissing } from "./learning";
 import type { Snapshot } from "./types";
 
 export type TrackPoint = {
@@ -40,25 +41,34 @@ export async function logTracks(snap: Snapshot): Promise<void> {
   const date = utcDateKey(new Date(snap.fetched_at));
   const tsSec = Math.floor(snap.fetched_at / 1000);
 
-  const writes = snap.aircraft
-    .filter((a) => a.airborne && a.lat != null && a.lon != null)
-    .map(async (a) => {
-      const key = `tracks:${a.tail}:${date}`;
-      const point: TrackPoint = {
-        lat: a.lat as number,
-        lon: a.lon as number,
-        alt: a.altitude_ft ?? null,
-        spd: a.ground_speed_kt ?? null,
-        trk: a.heading ?? null,
-        ts: tsSec,
-      };
-      try {
-        await redis.rpush(key, JSON.stringify(point));
-        await redis.expire(key, TTL_SECONDS);
-      } catch (e) {
-        console.warn(`[tracks] rpush failed for ${a.tail}:`, e);
-      }
-    });
+  const points = snap.aircraft.filter(
+    (a) => a.airborne && a.lat != null && a.lon != null,
+  );
+  // Seed the learning-state timer on the first ingest after this code
+  // ships. Idempotent NX-write — a no-op after the first call. Skip when
+  // we have nothing to write so an empty-sky deploy doesn't start the
+  // clock prematurely.
+  if (points.length > 0) {
+    await recordFirstSampleIfMissing(new Date(snap.fetched_at));
+  }
+
+  const writes = points.map(async (a) => {
+    const key = `tracks:${a.tail}:${date}`;
+    const point: TrackPoint = {
+      lat: a.lat as number,
+      lon: a.lon as number,
+      alt: a.altitude_ft ?? null,
+      spd: a.ground_speed_kt ?? null,
+      trk: a.heading ?? null,
+      ts: tsSec,
+    };
+    try {
+      await redis.rpush(key, JSON.stringify(point));
+      await redis.expire(key, TTL_SECONDS);
+    } catch (e) {
+      console.warn(`[tracks] rpush failed for ${a.tail}:`, e);
+    }
+  });
 
   await Promise.allSettled(writes);
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "env:pull": "vercel env pull .env.local --environment=development --yes",
+    "backfill:first-sample": "tsx --env-file=.env.local scripts/backfill-first-sample.ts",
     "backfill": "tsx --env-file=.env.local scripts/backfill.ts",
     "backfill:dry": "tsx --env-file=.env.local scripts/backfill.ts --dry",
     "backfill:resume": "tsx --env-file=.env.local scripts/backfill.ts --resume --yes"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# scripts/
+
+Operator scripts. Each one expects `.env.local` to be populated
+(`npm run env:pull` handles that on a fresh clone).
+
+| Script | Purpose | Idempotent? |
+|---|---|---|
+| `backfill.ts` | Pull historical OpenSky tracks for every fleet tail into KV at `tracks:{tail}:{YYYYMMDD}`. Honors a planning table + 429 retry. Run via `npm run backfill[:dry|:resume]`. | Yes — re-running skips already-present `(tail, date)` pairs. |
+| `backfill-first-sample.ts` | Backfill `meta:first_sample_ts` from the oldest existing track sample so the "Learning your sky" timer reflects real ingest history rather than deploy day. | Yes — refuses to overwrite an existing key without `--force`. |
+| `gen-icons.mjs` | (Legacy) regenerate icons from the brand kit. The current canonical assets live in `design/` and ship via `public/icons/` — generally don't touch this unless you're regenerating from a glyph change. | N/A |
+
+## When to run
+
+- **`backfill-first-sample.ts`** — once after the learning-state PR
+  ships, so production riders see an honest "Day 28 of 30" instead of
+  "Day 0." Without it the production timer starts at deploy day and
+  every previously-collected sample is invisible to the learning panel.
+- **`backfill.ts`** — when filling a fresh KV from a residential IP
+  (Vercel→OpenSky pays a latency tax that can rate-limit-out a full
+  fleet sweep).
+
+## Convention
+
+Scripts that hit OpenSky should share one rate-limit-respecting
+helper — `backfill.ts` already implements 429-retry with
+`X-Rate-Limit-Retry-After-Seconds` parsing and a 2.5 s / 4 s
+request/tail spacing. Lift that pattern verbatim if you write a new
+one; don't reinvent.

--- a/scripts/backfill-first-sample.ts
+++ b/scripts/backfill-first-sample.ts
@@ -1,0 +1,143 @@
+// One-shot backfill for meta:first_sample_ts. Reads every existing
+// tracks:* daily key, finds the oldest sample timestamp, and writes
+// the earliest as the system's "first sample" so the learning-state
+// timer reflects real ingest history rather than the deploy date.
+//
+// Run from a residential IP (.env.local must be populated; the
+// existing `npm run env:pull` flow handles this):
+//
+//   npx tsx --env-file=.env.local scripts/backfill-first-sample.ts
+//   npx tsx --env-file=.env.local scripts/backfill-first-sample.ts --dry
+//   npx tsx --env-file=.env.local scripts/backfill-first-sample.ts --force
+//
+// --dry  : prints what would happen, no writes
+// --force: overwrite even if meta:first_sample_ts is already set
+//
+// Idempotent under default flags — safe to re-run. Without --force the
+// script refuses to overwrite an existing key (so a second run after a
+// successful backfill won't reset the timer).
+
+import { getRedis } from "../lib/cache";
+
+const META_KEY = "meta:first_sample_ts";
+const TRACKS_PATTERN = "tracks:*";
+const SCAN_BATCH = 500;
+
+type Args = { dry: boolean; force: boolean };
+
+function parseArgs(): Args {
+  const out: Args = { dry: false, force: false };
+  for (const a of process.argv.slice(2)) {
+    if (a === "--dry") out.dry = true;
+    else if (a === "--force") out.force = true;
+    else if (a === "-h" || a === "--help") {
+      console.log(
+        "Usage: backfill-first-sample.ts [--dry] [--force]\n" +
+          "  --dry    show what would change, write nothing\n" +
+          "  --force  overwrite an existing meta:first_sample_ts",
+      );
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${a}`);
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+type TrackPoint = { ts?: number };
+function safeParse(raw: unknown): TrackPoint | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as TrackPoint;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw === "object") return raw as TrackPoint;
+  return null;
+}
+
+async function main() {
+  const args = parseArgs();
+  const redis = await getRedis();
+  if (!redis) {
+    console.error("KV not configured — set KV_REST_API_URL + KV_REST_API_TOKEN");
+    process.exit(1);
+  }
+
+  const existing = await redis.get(META_KEY);
+  if (typeof existing === "string" && existing.length > 0 && !args.force) {
+    console.log(`meta:first_sample_ts already set: ${existing}`);
+    console.log("re-run with --force to overwrite");
+    return;
+  }
+
+  console.log("scanning tracks:* keys…");
+  const keys: string[] = [];
+  let cursor: string | number = 0;
+  do {
+    const result = (await redis.scan(cursor, {
+      match: TRACKS_PATTERN,
+      count: SCAN_BATCH,
+    })) as [string | number, string[]];
+    keys.push(...result[1]);
+    cursor = result[0];
+  } while (String(cursor) !== "0");
+
+  if (keys.length === 0) {
+    const now = new Date().toISOString();
+    console.log(`no tracks:* keys found. seeding meta:first_sample_ts=${now} (timer starts now)`);
+    if (!args.dry) {
+      await redis.set(META_KEY, now);
+    }
+    return;
+  }
+
+  console.log(`scanning ${keys.length} tracks:* keys for the oldest sample…`);
+  let oldestSec: number | null = null;
+  let scanned = 0;
+  for (const key of keys) {
+    try {
+      // Each list is sorted oldest→newest by rpush order, so peek index 0.
+      const head = (await redis.lrange(key, 0, 0)) as unknown[];
+      const point = safeParse(head[0]);
+      const ts = typeof point?.ts === "number" ? point.ts : null;
+      if (ts != null && (oldestSec == null || ts < oldestSec)) {
+        oldestSec = ts;
+      }
+      scanned++;
+      if (scanned % 100 === 0) {
+        process.stdout.write(`  ${scanned}/${keys.length}…\r`);
+      }
+    } catch {
+      /* skip unreadable keys */
+    }
+  }
+  process.stdout.write("\n");
+
+  if (oldestSec == null) {
+    const now = new Date().toISOString();
+    console.log(`couldn't read any track samples. seeding meta:first_sample_ts=${now}`);
+    if (!args.dry) {
+      await redis.set(META_KEY, now);
+    }
+    return;
+  }
+
+  const oldestIso = new Date(oldestSec * 1000).toISOString();
+  const ageDays = Math.floor((Date.now() - oldestSec * 1000) / 86_400_000);
+  console.log(`oldest sample: ${oldestIso} (${ageDays} days ago)`);
+  if (args.dry) {
+    console.log("DRY RUN — no write performed");
+    return;
+  }
+  await redis.set(META_KEY, oldestIso);
+  console.log(`meta:first_sample_ts := ${oldestIso}`);
+}
+
+main().catch((e) => {
+  console.error("fatal:", e);
+  process.exit(1);
+});

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -45,7 +45,10 @@ function readEnvFile(p) {
   }
 }
 
-const env = readEnvFile(ENV_LOCAL);
+// On Vercel / CI there is no .env.local — env vars are injected directly
+// into process.env. Source from there and skip the file-missing nag.
+const isCI = process.env.VERCEL === "1" || process.env.CI === "true";
+const env = isCI ? { ...process.env } : readEnvFile(ENV_LOCAL);
 
 if (!env) {
   console.error(


### PR DESCRIPTION
## Summary

Ships a coherent, brand-voiced empty/partial-data state for every surface that depends on hot-zone or forecast learning. One canonical `<LearningPanel />` (card / banner / overlay) renders the same copy on home, radar, forecast, and now has a dedicated help-page entry.

Two stacked commits:

- **`0a66259` — foundation.** `lib/learning.ts` is the single source of truth (KV key `meta:first_sample_ts`, 30-day window, 5-min cache). `logTracks()` calls `recordFirstSampleIfMissing()` (Upstash NX-write) on the first non-empty snapshot so the timer self-seeds. Operator script `scripts/backfill-first-sample.ts` (idempotent, refuses overwrite without `--force`) seeds from the oldest existing `tracks:*` entry on first deploy. New `<LearningPanel />` component centralizes the copy.
- **`612faba` — wiring.** Each tab page server-fetches `getLearningState()` and threads it through to its client shell:
  - **Home** — `PredictionCard` renders `LearningPanel` (card variant) when still learning OR below the 10-event prediction floor.
  - **Radar** — `HotZoneLayer` renders the overlay variant when filtered zones come back empty AND we're still learning. Past threshold + empty filter shows a slim "no zones in your filter" banner instead.
  - **Forecast** — banner variant slots between the H1 and the grid when learning OR below 30 logged takeoffs. Intro tightens to mono-numeric "logged takeoffs" wording.
  - **Help** — new "Why is it still learning?" section explains the 30-day window and what each surface is gating; the troubleshooting bullet for empty hot zones now points at it.

## Voice review

| Surface | Eyebrow | Headline | Notes |
|---|---|---|---|
| Home (card) | `LEARNING YOUR SKY · DAY n OF 30` | "Channel 19's tuning in." | Single "Channel 19" garnish per page. |
| Radar (overlay) | same | same | Sits above the toggle row, doesn't fight map controls. |
| Forecast (banner) | same | — (banner skips headline) | Right-aligned `n/30 days` mono numeric. |

All numerics in mono. No emoji. No exclamation marks.

## Things Alex needs to do (post-merge)

- Run `npm run backfill:first-sample` once against prod KV so production riders see "Day 28 of 30" instead of "Day 0." Without this, the timer starts from deploy day and every previously-collected sample is invisible to the panel. Script is idempotent and refuses to overwrite an existing key without `--force`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (all routes including /forecast, /radar, /help compile)
- [x] Home renders LearningPanel card with correct eyebrow + headline + body
- [x] Forecast renders banner variant + tightened intro copy
- [x] Radar renders overlay when filtered zones return empty (verified by switching to Spokane SO operator inside Puget Sound region)
- [x] /help serves the new "Why is it still learning?" section
- [ ] Eyeball preview deploy on real device for hairline + spacing
- [ ] After backfill: confirm prod day-counter reflects oldest tracks:* entry, not deploy day

🤖 Generated with [Claude Code](https://claude.com/claude-code)