### PR TITLE
ci: GitHub Actions build job to catch Vercel-only failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build
+
+# Catches the failure modes that have repeatedly bitten us only on Vercel:
+#   1. scripts/check-env.mjs aborting because .env.local is missing
+#      (CI/Vercel inject env via process.env, not a file).
+#   2. next build's tsc pass hitting a tsconfig include/exclude that's fine
+#      locally but breaks in a clean checkout.
+# Both surface here BEFORE the deploy hits Vercel, so PRs fail in GitHub
+# instead of failing on the deploy gate.
+#
+# Mirrors Vercel as closely as we can without paying for it: Node 20,
+# clean install via npm ci, VERCEL=1 set so check-env.mjs takes the
+# CI code path.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel in-progress runs on the same ref when a new commit lands —
+# avoids burning Actions minutes on superseded commits.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck (root project)
+        run: npx tsc --noEmit
+
+      - name: Build (Vercel-equivalent env)
+        run: npm run build
+        env:
+          # Tells scripts/check-env.mjs to source from process.env instead
+          # of looking for .env.local.
+          VERCEL: "1"
+          # Required by check-env's BLOCK list. Real key lives in Vercel
+          # project settings; this placeholder only needs to be non-empty
+          # so the prebuild gate passes during CI.
+          NEXT_PUBLIC_MAPTILER_KEY: "ci-placeholder-not-deployed"


### PR DESCRIPTION
## Summary

Three PRs in a row hit Vercel build failures that wouldn't have surfaced from a local `npm run build`:

- **PR #6 / #7** — `scripts/check-env.mjs` aborted because Vercel has no `.env.local`. Locally there always is one.
- **PR #9** — `tests/visual` was in the root `tsconfig` `include`. Vercel's `next build` → `tsc` failed because `@playwright/test` lives in `tests/visual/node_modules`, not the root.

This adds a GitHub Actions workflow that mirrors Vercel's build environment: Node 20, `npm ci` (clean install — no cached `node_modules`), `VERCEL=1`, placeholder `NEXT_PUBLIC_MAPTILER_KEY`. Runs on every PR target main + every push to main.

If both classes of failure had been gated by this CI, all three previous failures would have been caught **before** Vercel ever tried.

## Notifications

GitHub already emails the commit author on workflow failure — no extra wiring needed. If you want richer notifications (Slack, push, etc.) later, that's a follow-up.

## What this is NOT

- Not a cron job that polls Vercel deployments. That's the second piece of the reliability story (separate PR if you want it).
- Not running the full `tests/visual/` Playwright pipeline on every PR — that's an on-demand sweep, not a per-commit gate. Adding it to CI would balloon run time and is its own decision.
- Not auto-fixing failures. Just alerting.

## Verification

- This PR will itself be the first run of the workflow. If the workflow YAML or the build itself fails, the PR fails CI — exactly the behavior we want.
- Local `npm run build` already passes (proves the workflow's commands are right; just need GitHub to actually run them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)