### PR TITLE
feat(time): rider-toggleable 24h ↔ 12h time format

### DIFF
--- a/app/(tabs)/forecast/page.tsx
+++ b/app/(tabs)/forecast/page.tsx
@@ -4,6 +4,7 @@ import { getForecastGrid } from "@/lib/predictor";
 import { ForecastGridView } from "@/components/ForecastGridView";
 import { LearningPanel } from "@/components/LearningPanel";
 import { getLearningState } from "@/lib/learning";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -21,6 +22,7 @@ export default async function ForecastPage() {
   const showLearning =
     learning.stillLearning ||
     grid.total_events < FORECAST_LEARNING_EVENT_FLOOR;
+  const hour12 = isHour12(getTimeFormatPref());
   return (
     <main
       style={{
@@ -88,7 +90,7 @@ export default async function ForecastPage() {
         />
       )}
 
-      <ForecastGridView grid={grid} />
+      <ForecastGridView grid={grid} hour12={hour12} />
     </main>
   );
 }

--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -3,6 +3,7 @@ import { getSnapshot } from "@/lib/snapshot";
 import { mockAirborneSnapshot } from "@/lib/mock";
 import { getRecentActivity } from "@/lib/activity";
 import { getLearningState } from "@/lib/learning";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 
@@ -20,12 +21,14 @@ export default async function Page({
   ]);
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
+  const hour12 = isHour12(getTimeFormatPref());
   return (
     <Glanceable
       initial={initial}
       mockOn={mockOn}
       initialActivity={activity}
       learning={learning}
+      hour12={hour12}
     />
   );
 }

--- a/app/(tabs)/plane/[tail]/page.tsx
+++ b/app/(tabs)/plane/[tail]/page.tsx
@@ -9,6 +9,7 @@ import { SS_TOKENS } from "@/lib/tokens";
 import { StatusPill } from "@/components/StatusPill";
 import { Card } from "@/components/Card";
 import { fmtAgo, fmtAgoTs, fmtAloft, formatTs } from "@/lib/time";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 import type { Aircraft } from "@/lib/types";
 import type { RecentFlightForTail } from "@/lib/flights";
 import { BackLink } from "@/components/BackLink";
@@ -52,6 +53,7 @@ export default async function PlanePage({ params, searchParams }: Props) {
   const live = snap.aircraft.find((a) => a.tail === tail);
   const up = Boolean(live?.airborne);
   const updatedSec = Math.max(0, Math.floor((Date.now() - snap.fetched_at) / 1000));
+  const hour12 = isHour12(getTimeFormatPref());
 
   return (
     <main
@@ -162,7 +164,7 @@ export default async function PlanePage({ params, searchParams }: Props) {
         <div className="ss-eyebrow" style={{ marginBottom: 8 }}>
           {recentFlight && !up ? "Last flight" : "Recent track"}
         </div>
-        <RecentTrackBlock tail={entry.tail} flight={recentFlight} />
+        <RecentTrackBlock tail={entry.tail} flight={recentFlight} hour12={hour12} />
       </section>
 
       <FleetMeta hex={fleetHex(entry).toUpperCase()} role={entry.roleDescription} />
@@ -350,9 +352,11 @@ function SquawkKV({ squawk }: { squawk: string | null }) {
 function RecentTrackBlock({
   tail,
   flight,
+  hour12,
 }: {
   tail: string;
   flight: RecentFlightForTail | null;
+  hour12: boolean;
 }) {
   if (!flight || flight.points.length < 2) {
     return (
@@ -385,10 +389,10 @@ function RecentTrackBlock({
             gap: 10,
           }}
         >
-          <KV label="FIRST" value={formatTs(session.start_ts, "datetime")} />
+          <KV label="FIRST" value={formatTs(session.start_ts, "datetime", { hour12 })} />
           <KV
             label={inProgress ? "NOW" : "LAST"}
-            value={formatTs(session.end_ts, "datetime")}
+            value={formatTs(session.end_ts, "datetime", { hour12 })}
           />
           <KV label="DURATION" value={fmtSessionDuration(session.duration_s)} />
           <KV label="SAMPLES" value={String(session.sample_count)} />

--- a/app/(tabs)/settings/alerts/actions.ts
+++ b/app/(tabs)/settings/alerts/actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { TIME_FORMAT_COOKIE, type TimeFormat } from "@/lib/user-prefs";
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+/** Persist the rider's 24h/12h pref. Cookie travels with every request, so
+ *  server + client always render the same value — no hydration footgun. */
+export async function setTimeFormatAction(formData: FormData): Promise<void> {
+  const raw = formData.get("format");
+  const next: TimeFormat = raw === "12" ? "12" : "24";
+  cookies().set({
+    name: TIME_FORMAT_COOKIE,
+    value: next,
+    path: "/",
+    maxAge: ONE_YEAR_SECONDS,
+    sameSite: "lax",
+    httpOnly: false,
+  });
+  // Revalidate every page that renders times so the new format takes effect
+  // on the next paint instead of waiting for a navigation.
+  revalidatePath("/", "layout");
+}

--- a/app/(tabs)/settings/alerts/page.tsx
+++ b/app/(tabs)/settings/alerts/page.tsx
@@ -1,4 +1,6 @@
 import { AlertsSettings } from "@/components/AlertsSettings";
+import { TimeFormatSetting } from "@/components/TimeFormatSetting";
+import { getTimeFormatPref } from "@/lib/user-prefs";
 
 export const metadata = {
   title: "Alerts",
@@ -8,5 +10,19 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default function AlertsPage() {
-  return <AlertsSettings />;
+  const timeFormat = getTimeFormatPref();
+  return (
+    <>
+      <AlertsSettings />
+      <div
+        style={{
+          maxWidth: 460,
+          margin: "16px auto 80px",
+          padding: "0 18px",
+        }}
+      >
+        <TimeFormatSetting current={timeFormat} />
+      </div>
+    </>
+  );
 }

--- a/app/admin/Editor.tsx
+++ b/app/admin/Editor.tsx
@@ -39,6 +39,7 @@ export function Editor({
   flags,
   flights,
   flash,
+  hour12,
 }: {
   registry: FleetEntry[];
   backups: BackupInfo[];
@@ -46,6 +47,7 @@ export function Editor({
   flags: Flags;
   flights: FlightSession[];
   flash: Flash;
+  hour12: boolean;
 }) {
   const [editingTail, setEditingTail] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
@@ -65,7 +67,7 @@ export function Editor({
       {flash.error && <FlashMsg kind="error" code={flash.error} />}
       {flash.saved && <FlashMsg kind="ok" code={flash.saved} />}
 
-      <RecentFlights flights={flights} />
+      <RecentFlights flights={flights} hour12={hour12} />
 
       <Section title="Registry" subtitle={`${registry.length} tails`}>
         <div style={{ overflowX: "auto" }}>
@@ -298,7 +300,7 @@ function NavLink({
 
 // ─── recent flights ────────────────────────────────────────────────────────
 
-function RecentFlights({ flights }: { flights: FlightSession[] }) {
+function RecentFlights({ flights, hour12 }: { flights: FlightSession[]; hour12: boolean }) {
   return (
     <section style={{ marginBottom: 28 }}>
       <div
@@ -328,7 +330,11 @@ function RecentFlights({ flights }: { flights: FlightSession[] }) {
           {flights.length} session{flights.length === 1 ? "" : "s"} · last 7 days
         </span>
       </div>
-      {flights.length === 0 ? <FlightsEmpty /> : <FlightsList flights={flights} />}
+      {flights.length === 0 ? (
+        <FlightsEmpty />
+      ) : (
+        <FlightsList flights={flights} hour12={hour12} />
+      )}
     </section>
   );
 }
@@ -395,7 +401,7 @@ function RadarPulse() {
   );
 }
 
-function FlightsList({ flights }: { flights: FlightSession[] }) {
+function FlightsList({ flights, hour12 }: { flights: FlightSession[]; hour12: boolean }) {
   return (
     <div
       style={{
@@ -406,7 +412,12 @@ function FlightsList({ flights }: { flights: FlightSession[] }) {
       }}
     >
       {flights.map((f, i) => (
-        <FlightRow key={`${f.tail}-${f.start_ts}`} flight={f} first={i === 0} />
+        <FlightRow
+          key={`${f.tail}-${f.start_ts}`}
+          flight={f}
+          first={i === 0}
+          hour12={hour12}
+        />
       ))}
     </div>
   );
@@ -415,9 +426,11 @@ function FlightsList({ flights }: { flights: FlightSession[] }) {
 function FlightRow({
   flight,
   first,
+  hour12,
 }: {
   flight: FlightSession;
   first: boolean;
+  hour12: boolean;
 }) {
   const sharePath = `/flight/${flight.tail}/${flightIdFromTs(flight.start_ts)}`;
   return (
@@ -455,8 +468,8 @@ function FlightRow({
       >
         <div style={{ fontSize: 12.5, color: SS_TOKENS.fg0 }}>
           {formatTs(flight.start_ts, "date-short")} ·{" "}
-          {formatTsBare(flight.start_ts, "time")} –{" "}
-          {formatTs(flight.end_ts, "time")}
+          {formatTsBare(flight.start_ts, "time", { hour12 })} –{" "}
+          {formatTs(flight.end_ts, "time", { hour12 })}
         </div>
         <div
           className="ss-mono"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -13,6 +13,7 @@ import { SS_TOKENS } from "@/lib/tokens";
 import { LoginForm } from "./LoginForm";
 import { Editor } from "./Editor";
 import { Logo } from "@/components/brand/Logo";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 
@@ -44,6 +45,8 @@ export default async function AdminPage({
       getRecentFlights(20),
     ]);
 
+  const hour12 = isHour12(getTimeFormatPref());
+
   return (
     <Editor
       registry={registry}
@@ -52,6 +55,7 @@ export default async function AdminPage({
       flags={{ speedWarningEnabled }}
       flights={flights}
       flash={{ error: searchParams.error, saved: searchParams.saved }}
+      hour12={hour12}
     />
   );
 }

--- a/app/admin/spots/page.tsx
+++ b/app/admin/spots/page.tsx
@@ -8,6 +8,7 @@ import { SS_TOKENS } from "@/lib/tokens";
 import { LoginForm } from "../LoginForm";
 import { AdminHeader } from "../tracks/AdminHeader";
 import { formatTs } from "@/lib/time";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -41,6 +42,7 @@ export default async function AdminSpotsPage({
   }
 
   const spots = await listRecentSpots(100);
+  const hour12 = isHour12(getTimeFormatPref());
 
   return (
     <main
@@ -102,7 +104,7 @@ export default async function AdminSpotsPage({
                         borderTop: `.5px solid ${SS_TOKENS.hairline}`,
                       }}
                     >
-                      <Td mono>{formatTs(s.ts, "datetime")}</Td>
+                      <Td mono>{formatTs(s.ts, "datetime", { hour12 })}</Td>
                       <Td mono>{s.lat.toFixed(4)}</Td>
                       <Td mono>{s.lon.toFixed(4)}</Td>
                       <Td>

--- a/app/admin/tracks/[tail]/page.tsx
+++ b/app/admin/tracks/[tail]/page.tsx
@@ -20,6 +20,7 @@ import {
   fmtDuration,
   ktToMph,
 } from "../fmt";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -60,6 +61,7 @@ export default async function TailTracksPage({ params, searchParams }: Props) {
       return { date, samples };
     }),
   );
+  const hour12 = isHour12(getTimeFormatPref());
 
   // Recent samples: pull last RECENT_SAMPLES from the most recent day(s).
   const recentSamples: typeof dayBlocks[number]["samples"] = [];
@@ -113,11 +115,11 @@ export default async function TailTracksPage({ params, searchParams }: Props) {
         <Stat label="DAYS WITH DATA" value={String(summary.daysWithData)} />
         <Stat
           label="FIRST SAMPLE"
-          value={fmtPtDateTime(summary.firstSampleTs)}
+          value={fmtPtDateTime(summary.firstSampleTs, hour12)}
         />
         <Stat
           label="LAST SAMPLE"
-          value={fmtPtDateTime(summary.lastSampleTs)}
+          value={fmtPtDateTime(summary.lastSampleTs, hour12)}
         />
       </Card>
 
@@ -153,9 +155,9 @@ export default async function TailTracksPage({ params, searchParams }: Props) {
                         marginTop: 2,
                       }}
                     >
-                      {b.samples.length} samples · {fmtPtTime(first?.ts)}
+                      {b.samples.length} samples · {fmtPtTime(first?.ts, hour12)}
                       {" → "}
-                      {fmtPtTime(last?.ts)} · {duration}
+                      {fmtPtTime(last?.ts, hour12)} · {duration}
                     </div>
                   </div>
                   {b.samples.length >= 2 && (
@@ -197,7 +199,7 @@ export default async function TailTracksPage({ params, searchParams }: Props) {
                     borderTop: `.5px solid ${SS_TOKENS.hairline}`,
                   }}
                 >
-                  <Td mono>{fmtPtDateTime(p.ts)}</Td>
+                  <Td mono>{fmtPtDateTime(p.ts, hour12)}</Td>
                   <Td mono>{p.lat.toFixed(4)}</Td>
                   <Td mono>{p.lon.toFixed(4)}</Td>
                   <Td mono>{p.alt != null ? `${p.alt}'` : "—"}</Td>

--- a/app/admin/tracks/fmt.ts
+++ b/app/admin/tracks/fmt.ts
@@ -28,14 +28,20 @@ export function utcDateKey(d: Date): string {
   return `${y}${m}${day}`;
 }
 
-export function fmtPtTime(tsSec: number | null | undefined): string {
+export function fmtPtTime(
+  tsSec: number | null | undefined,
+  hour12 = false,
+): string {
   if (tsSec == null) return "—";
-  return formatTs(tsSec * 1000, "time-sec");
+  return formatTs(tsSec * 1000, "time-sec", { hour12 });
 }
 
-export function fmtPtDateTime(tsSec: number | null | undefined): string {
+export function fmtPtDateTime(
+  tsSec: number | null | undefined,
+  hour12 = false,
+): string {
   if (tsSec == null) return "—";
-  return formatTs(tsSec * 1000, "datetime");
+  return formatTs(tsSec * 1000, "datetime", { hour12 });
 }
 
 export function fmtDuration(spanSec: number): string {

--- a/app/flight/[tail]/[flightId]/page.tsx
+++ b/app/flight/[tail]/[flightId]/page.tsx
@@ -12,6 +12,7 @@ import { getFlightById, parseFlightId } from "@/lib/flights";
 import { SS_TOKENS } from "@/lib/tokens";
 import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { fmtDurationHuman, formatTs } from "@/lib/time";
+import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 
 export const dynamic = "force-dynamic";
 
@@ -64,6 +65,7 @@ export default async function FlightSharePage({ params }: Props) {
   }
 
   const { session, points } = flight;
+  const hour12 = isHour12(getTimeFormatPref());
 
   return (
     <main
@@ -174,8 +176,8 @@ export default async function FlightSharePage({ params }: Props) {
             gap: 12,
           }}
         >
-          <KV label="FIRST SEEN" value={formatTs(session.start_ts, "datetime")} />
-          <KV label="LAST SEEN" value={formatTs(session.end_ts, "datetime")} />
+          <KV label="FIRST SEEN" value={formatTs(session.start_ts, "datetime", { hour12 })} />
+          <KV label="LAST SEEN" value={formatTs(session.end_ts, "datetime", { hour12 })} />
           <KV label="DURATION" value={fmtDurationHuman(session.duration_s)} />
           <KV label="SAMPLES" value={String(session.sample_count)} />
           <KV

--- a/components/ForecastGridView.tsx
+++ b/components/ForecastGridView.tsx
@@ -10,7 +10,13 @@ import { pacificNow } from "@/lib/time";
 
 const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 
-export function ForecastGridView({ grid }: { grid: ForecastGrid }) {
+export function ForecastGridView({
+  grid,
+  hour12 = false,
+}: {
+  grid: ForecastGrid;
+  hour12?: boolean;
+}) {
   const maxProb = useMemo(
     () => Math.max(...grid.cells.map((c) => c.probability), 0.01),
     [grid.cells],
@@ -69,7 +75,7 @@ export function ForecastGridView({ grid }: { grid: ForecastGrid }) {
         </div>
       </div>
 
-      <CellDetail cell={selected} />
+      <CellDetail cell={selected} hour12={hour12} />
     </div>
   );
 }
@@ -142,7 +148,7 @@ function heatColor(p: number, max: number): string {
   return `rgba(245,184,64,${alpha.toFixed(3)})`;
 }
 
-function CellDetail({ cell }: { cell: ForecastCell | null }) {
+function CellDetail({ cell, hour12 }: { cell: ForecastCell | null; hour12: boolean }) {
   if (!cell) {
     return (
       <div
@@ -187,7 +193,7 @@ function CellDetail({ cell }: { cell: ForecastCell | null }) {
             letterSpacing: ".04em",
           }}
         >
-          {DAYS[cell.dow]} · {fmtHour(cell.hour)} PT
+          {DAYS[cell.dow]} · {fmtHour(cell.hour, hour12)} PT
         </span>
         <span
           className="ss-mono"
@@ -221,6 +227,10 @@ function CellDetail({ cell }: { cell: ForecastCell | null }) {
   );
 }
 
-function fmtHour(h: number): string {
-  return `${String(h).padStart(2, "0")}:00`;
+function fmtHour(h: number, hour12: boolean): string {
+  if (!hour12) return `${String(h).padStart(2, "0")}:00`;
+  if (h === 0) return "12:00 AM";
+  if (h < 12) return `${h}:00 AM`;
+  if (h === 12) return "12:00 PM";
+  return `${h - 12}:00 PM`;
 }

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -27,6 +27,7 @@ type Props = {
   mockOn?: boolean;
   initialActivity?: ActivityEntry[];
   learning?: LearningState;
+  hour12?: boolean;
 };
 
 export function Glanceable({
@@ -34,6 +35,7 @@ export function Glanceable({
   mockOn = false,
   initialActivity = [],
   learning,
+  hour12 = false,
 }: Props) {
   const snap = useAircraft(initial, mockOn);
   const [updatedAgo, setUpdatedAgo] = useState<number>(0);
@@ -176,7 +178,7 @@ export function Glanceable({
 
       {others.length > 0 && <Others others={others} />}
 
-      <PredictionCard learning={learning} />
+      <PredictionCard learning={learning} hour12={hour12} />
 
       <Footer />
     </main>

--- a/components/PredictionCard.tsx
+++ b/components/PredictionCard.tsx
@@ -24,7 +24,13 @@ const FALLBACK_LEARNING: LearningState = {
   stillLearning: true,
 };
 
-export function PredictionCard({ learning }: { learning?: LearningState }) {
+export function PredictionCard({
+  learning,
+  hour12 = false,
+}: {
+  learning?: LearningState;
+  hour12?: boolean;
+}) {
   const [data, setData] = useState<PredictorOutput | null>(null);
 
   useEffect(() => {
@@ -91,7 +97,7 @@ export function PredictionCard({ learning }: { learning?: LearningState }) {
             className="ss-mono"
             style={{ fontSize: 12, color: SS_TOKENS.fg1, marginTop: 4 }}
           >
-            {fmtPredictionTimeRange(top.window_start, top.window_end)}
+            {fmtPredictionTimeRange(top.window_start, top.window_end, hour12)}
           </div>
         </div>
         <div style={{ textAlign: "right", flexShrink: 0 }}>
@@ -169,10 +175,14 @@ function fmtPredictionDayLabel(iso: string): string {
   return formatTs(ts, "date-weekday");
 }
 
-function fmtPredictionTimeRange(startIso: string, endIso: string): string {
+function fmtPredictionTimeRange(
+  startIso: string,
+  endIso: string,
+  hour12: boolean,
+): string {
   const start = new Date(startIso).getTime();
   const end = new Date(endIso).getTime();
-  return `${formatTsBare(start, "hour-min")} – ${formatTs(end, "hour-min")}`;
+  return `${formatTsBare(start, "hour-min", { hour12 })} – ${formatTs(end, "hour-min", { hour12 })}`;
 }
 
 function confidenceLabel(c: PredictionWindow["confidence_level"]): string {

--- a/components/TimeFormatSetting.tsx
+++ b/components/TimeFormatSetting.tsx
@@ -1,0 +1,123 @@
+// Server component — renders the 24h/12h toggle as a plain form. The
+// server action sets a cookie and revalidates so every rendered time
+// across the app picks up the new format on the next paint.
+
+import { SS_TOKENS } from "@/lib/tokens";
+import { type TimeFormat } from "@/lib/user-prefs";
+import { setTimeFormatAction } from "@/app/(tabs)/settings/alerts/actions";
+
+export function TimeFormatSetting({ current }: { current: TimeFormat }) {
+  return (
+    <section
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 14,
+        padding: "16px 18px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <div>
+        <div
+          className="ss-mono"
+          style={{
+            fontSize: 9.5,
+            color: SS_TOKENS.fg2,
+            letterSpacing: ".12em",
+            textTransform: "uppercase",
+            marginBottom: 6,
+          }}
+        >
+          Display
+        </div>
+        <h2
+          style={{
+            fontSize: 18,
+            fontWeight: 700,
+            color: SS_TOKENS.fg0,
+            margin: 0,
+            letterSpacing: "-.01em",
+          }}
+        >
+          Time format
+        </h2>
+        <p
+          style={{
+            fontSize: 13,
+            color: SS_TOKENS.fg1,
+            lineHeight: 1.5,
+            marginTop: 6,
+            marginBottom: 0,
+          }}
+        >
+          24-hour reads cleaner; 12-hour is what most US riders are used to.
+          Times are PT either way.
+        </p>
+      </div>
+
+      <form
+        action={setTimeFormatAction}
+        style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
+      >
+        <FormatChoice value="24" current={current} label="24-hour" sample="15:42 PT" />
+        <FormatChoice value="12" current={current} label="12-hour" sample="3:42 PM PT" />
+      </form>
+    </section>
+  );
+}
+
+function FormatChoice({
+  value,
+  current,
+  label,
+  sample,
+}: {
+  value: TimeFormat;
+  current: TimeFormat;
+  label: string;
+  sample: string;
+}) {
+  const active = current === value;
+  return (
+    <button
+      type="submit"
+      name="format"
+      value={value}
+      aria-pressed={active}
+      style={{
+        flex: 1,
+        minWidth: 140,
+        padding: "12px 14px",
+        borderRadius: 12,
+        border: `.5px solid ${active ? SS_TOKENS.alert : SS_TOKENS.hairline2}`,
+        background: active ? SS_TOKENS.alertDim : SS_TOKENS.bg2,
+        color: SS_TOKENS.fg0,
+        cursor: "pointer",
+        textAlign: "left",
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+      }}
+    >
+      <span
+        className="ss-mono"
+        style={{
+          fontSize: 12,
+          letterSpacing: ".06em",
+          color: active ? SS_TOKENS.alert : SS_TOKENS.fg1,
+          fontWeight: 700,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        className="ss-mono"
+        style={{ fontSize: 13, color: SS_TOKENS.fg0 }}
+      >
+        {sample}
+      </span>
+    </button>
+  );
+}

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -27,32 +27,51 @@ const TIME_BEARING: ReadonlySet<FormatStyle> = new Set([
   "hour-min",
 ]);
 
-export function formatTs(
-  tsMs: number | null | undefined,
-  style: FormatStyle,
-): string {
-  if (tsMs == null || Number.isNaN(tsMs)) return "—";
-  const d = new Date(tsMs);
-  const tz = PT_TZ;
-  let out: string;
-  switch (style) {
-    case "time":
-    case "hour-min":
-      out = d.toLocaleTimeString([], {
-        hour: "2-digit",
+export type FormatOpts = {
+  /** Render as 12-hour with AM/PM. Default false (24-hour, brand default). */
+  hour12?: boolean;
+};
+
+function timeOpts(hour12: boolean): Intl.DateTimeFormatOptions {
+  return hour12
+    ? { hour: "numeric", minute: "2-digit", hour12: true, timeZone: PT_TZ }
+    : { hour: "2-digit", minute: "2-digit", hour12: false, timeZone: PT_TZ };
+}
+
+function timeSecOpts(hour12: boolean): Intl.DateTimeFormatOptions {
+  return hour12
+    ? {
+        hour: "numeric",
         minute: "2-digit",
-        hour12: false,
-        timeZone: tz,
-      });
-      break;
-    case "time-sec":
-      out = d.toLocaleTimeString([], {
+        second: "2-digit",
+        hour12: true,
+        timeZone: PT_TZ,
+      }
+    : {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
         hour12: false,
-        timeZone: tz,
-      });
+        timeZone: PT_TZ,
+      };
+}
+
+export function formatTs(
+  tsMs: number | null | undefined,
+  style: FormatStyle,
+  opts?: FormatOpts,
+): string {
+  if (tsMs == null || Number.isNaN(tsMs)) return "—";
+  const d = new Date(tsMs);
+  const hour12 = opts?.hour12 ?? false;
+  let out: string;
+  switch (style) {
+    case "time":
+    case "hour-min":
+      out = d.toLocaleTimeString([], timeOpts(hour12));
+      break;
+    case "time-sec":
+      out = d.toLocaleTimeString([], timeSecOpts(hour12));
       break;
     case "date":
       // sv-SE forces ISO-style YYYY-MM-DD regardless of viewer locale.
@@ -60,30 +79,25 @@ export function formatTs(
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
-        timeZone: tz,
+        timeZone: PT_TZ,
       });
       break;
     case "date-short":
       out = d.toLocaleDateString([], {
         month: "short",
         day: "numeric",
-        timeZone: tz,
+        timeZone: PT_TZ,
       });
       break;
     case "date-weekday":
       out = d.toLocaleDateString([], {
         weekday: "long",
-        timeZone: tz,
+        timeZone: PT_TZ,
       });
       break;
     case "datetime": {
       const date = formatTs(tsMs, "date");
-      const time = d.toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-        timeZone: tz,
-      });
+      const time = d.toLocaleTimeString([], timeOpts(hour12));
       return `${date} ${time} PT`;
     }
     case "iso-utc":
@@ -96,9 +110,10 @@ export function formatTs(
 export function formatTsBare(
   tsMs: number | null | undefined,
   style: FormatStyle,
+  opts?: FormatOpts,
 ): string {
   if (tsMs == null || Number.isNaN(tsMs)) return "—";
-  return formatTs(tsMs, style).replace(/\s+PT$/, "");
+  return formatTs(tsMs, style, opts).replace(/\s+PT$/, "");
 }
 
 /**

--- a/lib/user-prefs.ts
+++ b/lib/user-prefs.ts
@@ -1,0 +1,20 @@
+// Server-side reader for per-rider display preferences. Cookies are the
+// transport so the SAME render path (server + client) sees the same value
+// — no SSR/CSR divergence. Mirrors the simplicity of the rest of the app:
+// no auth, no DB, just a cookie.
+
+import { cookies } from "next/headers";
+
+export const TIME_FORMAT_COOKIE = "ss_time_format";
+export type TimeFormat = "24" | "12";
+export const DEFAULT_TIME_FORMAT: TimeFormat = "24";
+
+/** Read the rider's preferred time format. Server Components only. */
+export function getTimeFormatPref(): TimeFormat {
+  const v = cookies().get(TIME_FORMAT_COOKIE)?.value;
+  return v === "12" ? "12" : DEFAULT_TIME_FORMAT;
+}
+
+export function isHour12(pref: TimeFormat): boolean {
+  return pref === "12";
+}


### PR DESCRIPTION
## Summary

Per-rider 24-hour ↔ 12-hour preference, persisted in a cookie. Toggle lives on `/settings/alerts` next to the alert prefs. Default is 24-hour (matches BRAND.md §3); 12-hour is opt-in.

## Why a cookie

Same trap as the LocalTime hydration footgun we just deleted: if server defaults to 24h and the client reads localStorage and re-renders 12h, every time field flickers. A cookie travels with every request, so the server reads it during render and the client reads the same value — no divergence.

## Flow

```
/settings/alerts
  └─ TimeFormatSetting (server component)
      └─ <form action={setTimeFormatAction}>
          └─ writes ss_time_format=12|24
          └─ revalidatePath("/", "layout")
```

Every server page that shows times calls `getTimeFormatPref()` (reads the cookie via `next/headers`) and threads `hour12` into `formatTs(..., { hour12 })`. Client components (`PredictionCard`, `ForecastGridView`, `Editor`) receive `hour12` as a prop from their server parent.

## Surfaces wired

- Home `PredictionCard` (sweep window range)
- `/forecast` (cell-detail hour label)
- `/plane/[tail]` (FIRST/LAST KV)
- `/flight/[tail]/[flightId]` share page (FIRST SEEN/LAST SEEN KV)
- `/admin` (recent flights row, spots table, tracks pages)
- OG images stay 24h (rendered for unknown viewers — can't read the viewer's cookie)

## Verification (local)

Started dev server, hit `/settings/alerts` → toggle renders with 24h pressed by default, sample reads `15:42 PT` / `3:42 PM PT`. Clicked the 12h button → cookie set to `ss_time_format=12` → navigated to `/plane/N2446X`:

| Pref | Renders as |
|---|---|
| 24h (default) | `12:40 PT` / `14:26 PT` |
| 12h | `12:40 PM PT` / `2:26 PM PT` |

Round-tripped back to 24h via the toggle — confirmed every page re-renders with the new pref. No console warnings, no hydration errors.

## Tradeoffs

- **OG images stay 24h** — they're pre-rendered server-side once and cached for unknown viewers. Acceptable.
- **First-time visitors see 24h** until they toggle. Matches the brand default.
- **Default still 24h** because BRAND.md §3 explicitly calls for 24-hour. The 12h preference is opt-in, not default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)