### PR TITLE
docs(readme): Working with this codebase quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ Full setup: see `HOW_TO_HAND_OFF.md` §2.5.
 
 ---
 
+## Working with this codebase
+
+```bash
+# First-time setup (per the section above)
+npm install && npx vercel link && npm run env:pull && npm run dev
+
+# Common tasks
+npm run build                # production build (predev env-check runs first)
+npx tsc --noEmit             # strict TypeScript check
+
+# Visual + functional + a11y + coherence audit (~5 min)
+cd tests/visual && SS_VISUAL_BASE_URL=https://smokysignal.app npm test
+node scripts/categorize-bugs.mjs
+node scripts/build-report.mjs
+open out/report.html
+
+# Historical track backfill (rate-limit-aware, idempotent, prompt before fetching)
+npm run backfill                       # pre-scan + fetch missing
+npm run backfill:dry                   # pre-scan + planning table only
+npm run backfill -- --tails N305DK,N305RC,N2446X
+npm run backfill -- --since 7d
+```
+
+The product roadmap lives in `docs/ROADMAP.md` with explicit Now / Next /
+Later / Maybe-Never tiering and the rationale for each item. Brand voice
+rules (hard) live in `design/BRAND.md`. Both docs are load-bearing — read
+once at the start of any meaningful contribution.
+
+---
+
 ## Fidelity
 
 **High-fidelity** for visuals, layout, copy, and interaction logic. Final colors, typography, spacing, component composition, and state behavior are all locked. Pixel-match the designs.


### PR DESCRIPTION
## Summary

Per Roadmap **N6**. README.md is the design-handoff doc from pre-build. Added a "Working with this codebase" section covering: build/typecheck commands, the visual audit pipeline, backfill commands, and pointers to `docs/ROADMAP.md` + `design/BRAND.md`.

## Diff

1 file (`README.md`), +30 lines, no behavior change.

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Build clean (no code touched)
- ✓ Diff ≤ 200 lines (30)
- ✓ Diff ≤ 5 files (1)
- ✓ All paths allow-listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)