### PR TITLE
chore(ci): hourly watchdog for failed prod deploys

### DIFF
--- a/.github/workflows/deploy-watchdog.yml
+++ b/.github/workflows/deploy-watchdog.yml
@@ -1,0 +1,45 @@
+name: Deploy Watchdog
+
+# Hourly check for failed production deploys on Vercel. If the most
+# recent prod deployment is in ERROR state, fail this workflow run —
+# GitHub emails the commit author per the repo's notification settings.
+#
+# Auto-skips cleanly when VERCEL_TOKEN is not configured (e.g. on a
+# fork). Set VERCEL_TOKEN + VERCEL_PROJECT_ID in repo Secrets to
+# activate.
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-watchdog
+  cancel-in-progress: true
+
+jobs:
+  check-prod-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check latest prod deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "::warning::VERCEL_TOKEN or VERCEL_PROJECT_ID not set — watchdog noop. Configure Secrets to activate."
+            exit 0
+          fi
+          LATEST=$(curl -fsS \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&target=production&limit=1")
+          STATE=$(echo "$LATEST" | jq -r '.deployments[0].state // "UNKNOWN"')
+          URL=$(echo "$LATEST" | jq -r '.deployments[0].url // ""')
+          CREATED=$(echo "$LATEST" | jq -r '.deployments[0].createdAt // 0')
+          AGE_MIN=$(( ($(date +%s%3N) - CREATED) / 60000 ))
+          echo "Latest prod deploy: state=$STATE age=${AGE_MIN}m url=$URL"
+          if [ "$STATE" = "ERROR" ]; then
+            echo "::error::Production deployment failed: https://$URL (age ${AGE_MIN}m)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Per Roadmap **N4**. Hourly GitHub Action that polls Vercel's deployments API; if the latest prod deploy is in `ERROR` state, the workflow fails and GitHub emails the commit author.

CI from PR #10 catches **build-time** failures before deploy. This watchdog catches anything that breaks **after** deploy (env-var rot, runtime errors that survive build, broken cron schedules).

## Things Alex needs to do (one-time, blocking activation)

- [ ] Add `VERCEL_TOKEN` to repo Secrets — generate at https://vercel.com/account/tokens
- [ ] Add `VERCEL_PROJECT_ID` to repo Secrets — Vercel project Settings → General → Project ID
- [ ] Confirm GitHub email notifications are enabled for workflow failures (Settings → Notifications)

The workflow self-skips cleanly when secrets are missing, so this PR is safe to merge before they're set — just no-ops every hour until activated.

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Diff +45 lines, 1 file
- ✓ All paths allow-listed (`.github/workflows/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)