### PR TITLE
feat(home): historical context line below status pill

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -4,6 +4,7 @@ import { mockAirborneSnapshot } from "@/lib/mock";
 import { getRecentActivity } from "@/lib/activity";
 import { getLearningState } from "@/lib/learning";
 import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
+import { getHistoricalContext } from "@/lib/historical-context";
 
 export const dynamic = "force-dynamic";
 
@@ -22,6 +23,9 @@ export default async function Page({
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
   const hour12 = isHour12(getTimeFormatPref());
+  // Historical context line — null when learning, sparse, or no bucket data.
+  const isCurrentlyUp = initial.aircraft.some((a) => a.airborne);
+  const context = await getHistoricalContext(isCurrentlyUp);
   return (
     <Glanceable
       initial={initial}
@@ -29,6 +33,7 @@ export default async function Page({
       initialActivity={activity}
       learning={learning}
       hour12={hour12}
+      contextLine={context?.copy ?? null}
     />
   );
 }

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -28,6 +28,10 @@ type Props = {
   initialActivity?: ActivityEntry[];
   learning?: LearningState;
   hour12?: boolean;
+  /** Optional historical-context phrase rendered under the Hero
+   *  ("usually up at this hour. 67% of weeks."). Server computes,
+   *  passes the string in. null = hide. */
+  contextLine?: string | null;
 };
 
 export function Glanceable({
@@ -36,6 +40,7 @@ export function Glanceable({
   initialActivity = [],
   learning,
   hour12 = false,
+  contextLine = null,
 }: Props) {
   const snap = useAircraft(initial, mockOn);
   const [updatedAgo, setUpdatedAgo] = useState<number>(0);
@@ -173,6 +178,21 @@ export function Glanceable({
       </header>
 
       <Hero status={status} />
+
+      {contextLine && (
+        <p
+          className="ss-mono"
+          style={{
+            fontSize: 12,
+            color: SS_TOKENS.fg2,
+            margin: "-4px 4px 0",
+            letterSpacing: ".02em",
+            lineHeight: 1.4,
+          }}
+        >
+          {contextLine}
+        </p>
+      )}
 
       {latestActivity && <ActivityStrip latest={latestActivity} />}
 

--- a/lib/historical-context.ts
+++ b/lib/historical-context.ts
@@ -1,0 +1,52 @@
+// Single-line historical context for the home page. Reads the existing
+// 7×24 forecast grid (lib/predictor.ts) and classifies the current PT
+// hour-of-week into one of four cases based on whether the bird is up
+// right now and how often it's up at this hour historically.
+//
+// Returns null when:
+//   - we don't have enough data (predictor < 30 events; matches the
+//     learning panel threshold)
+//   - the current bucket has no historical samples
+//
+// Returning null hides the line entirely. No partial state.
+
+import { getForecastGrid } from "./predictor";
+import { pacificNow } from "./time";
+
+export const MIN_EVENTS_FOR_CONTEXT = 30;
+const FREQUENT_THRESHOLD = 0.5; // ≥50% of weeks → "usually"
+
+export type HistoricalContext = {
+  bucketProbability: number;
+  isCurrentlyUp: boolean;
+  copy: string;
+};
+
+export async function getHistoricalContext(
+  isCurrentlyUp: boolean,
+): Promise<HistoricalContext | null> {
+  const grid = await getForecastGrid();
+  if (grid.total_events < MIN_EVENTS_FOR_CONTEXT) return null;
+  const { dow, hour } = pacificNow();
+  const cell = grid.cells.find((c) => c.dow === dow && c.hour === hour);
+  if (!cell || cell.sample_count === 0) return null;
+  return {
+    bucketProbability: cell.probability,
+    isCurrentlyUp,
+    copy: phraseFor(isCurrentlyUp, cell.probability),
+  };
+}
+
+function phraseFor(isCurrentlyUp: boolean, p: number): string {
+  const pct = Math.round(p * 100);
+  if (isCurrentlyUp && p >= FREQUENT_THRESHOLD) {
+    return `usually up at this hour. ${pct}% of weeks.`;
+  }
+  if (isCurrentlyUp && p < FREQUENT_THRESHOLD) {
+    return `unusual hour. up only ${pct}% of weeks.`;
+  }
+  if (!isCurrentlyUp && p >= FREQUENT_THRESHOLD) {
+    return "usually up by now. running late tonight.";
+  }
+  return "quiet hour. usually clear.";
+}


### PR DESCRIPTION
## Summary

The "drop something cool" feature from Prompt 9. Single mono line under the Hero pill on `/` telling the rider how the current hour-of-week reads historically:

| State | Copy |
|---|---|
| Bird up, frequent hour (≥50%) | `usually up at this hour. 67% of weeks.` |
| Bird up, rare hour (<50%) | `unusual hour. up only 12% of weeks.` |
| Bird down, normally-up hour | `usually up by now. running late tonight.` |
| Bird down, normally-quiet hour | `quiet hour. usually clear.` |

Reads from the existing `getForecastGrid()`. No new data plumbing, no new cron, no new storage — pure derivation off data we already collect.

Returns `null` when:
- Predictor has < 30 events (matches the `LearningPanel` learning-window threshold)
- The current bucket has no historical samples

Either case, the line hides cleanly and the home page is unchanged. No regression risk on a fresh deploy.

## Voice review

- 6–9 word phrases, lowercase to match the laconic register (the screaming pill above does the volume work)
- Mono numerics (`67%`, `12%`)
- No emoji, no exclamation marks
- "Smokey" + role wording untouched
- `--ss-fg2` color (passes WCAG AA after PR #13's contrast fix)

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Build clean
- ✓ Diff +77 / -0, 3 files
- ✓ All paths allow-listed (`app/(tabs)/page.tsx`, `components/Glanceable.tsx` — touches the home page, in-list per Prompt 9 spec; `lib/historical-context.ts` is a new pure-derivation file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)