### PR TITLE
fix(a11y): N5 contrast cleanup — remaining text fg3 → fg2

### DIFF
--- a/app/(tabs)/plane/[tail]/page.tsx
+++ b/app/(tabs)/plane/[tail]/page.tsx
@@ -291,7 +291,9 @@ function SquawkKV({ squawk }: { squawk: string | null }) {
   const value = squawk ?? "—";
   let alertNote: string | null = null;
   if (!squawk) {
-    color = SS_TOKENS.fg3;
+    // fg2 not fg3 — fg3 fails WCAG AA on bg-0 for body text. Same
+    // fix pattern as the FleetMeta footer (PR #13).
+    color = SS_TOKENS.fg2;
   } else if (squawk === "7700" || squawk === "7500") {
     color = SS_TOKENS.danger;
     alertNote = squawk === "7700" ? "EMERGENCY" : "HIJACK";

--- a/app/help/HelpView.tsx
+++ b/app/help/HelpView.tsx
@@ -116,7 +116,9 @@ export function HelpMarkdown({ source }: { source: string }) {
                 style={
                   isAnchor
                     ? {
-                        color: SS_TOKENS.fg3,
+                        // fg2 not fg3 — anchor "#" link is body text on
+                        // hover and needs WCAG AA contrast (4.5:1).
+                        color: SS_TOKENS.fg2,
                         textDecoration: "none",
                         marginLeft: 8,
                         opacity: 0,

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -151,7 +151,9 @@ function Row({ entry, first }: { entry: ActivityEntry; first: boolean }) {
       <span
         style={{
           fontSize: 18,
-          color: SS_TOKENS.fg3,
+          // fg2 not fg3 — chevron is a navigation affordance and needs
+          // visible contrast on the row background.
+          color: SS_TOKENS.fg2,
           flexShrink: 0,
           lineHeight: 1,
         }}


### PR DESCRIPTION
## Summary

Per Roadmap **N5**. Three remaining call sites where `SS_TOKENS.fg3` was used for visible text:

| File | Element | Visibility |
|---|---|---|
| `app/(tabs)/plane/[tail]/page.tsx` | Squawk badge "—" placeholder | When transponder hasn't been seen |
| `app/help/HelpView.tsx` | Anchor "#" link suffix on headings | On hover |
| `components/ActivityFeed.tsx` | Row "›" chevron | Always (navigation affordance) |

Each fails WCAG AA 4.5:1 against `bg-0`. Bumped to `fg2` (~5.2:1) — same fix pattern as PR #13's FleetMeta footer.

**Decorative `fg3` usages left alone** because they're not body text:
- Rotating logo on `/404` + `/about` origin glyphs (visual texture)
- Blockquote border on `/help`
- Speedometer tick stroke

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Build clean
- ✓ Diff +9 / -3, 3 files
- ✓ All paths allow-listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)