### PR TITLE
feat(freshness): N7 — LAST SAMPLE indicator on home + radar

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -5,6 +5,7 @@ import { getRecentActivity } from "@/lib/activity";
 import { getLearningState } from "@/lib/learning";
 import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 import { getHistoricalContext } from "@/lib/historical-context";
+import { getFreshness } from "@/lib/freshness";
 
 export const dynamic = "force-dynamic";
 
@@ -15,10 +16,11 @@ export default async function Page({
 }: {
   searchParams: SP;
 }) {
-  const [real, activity, learning] = await Promise.all([
+  const [real, activity, learning, freshness] = await Promise.all([
     getSnapshot(),
     getRecentActivity(1),
     getLearningState(),
+    getFreshness(),
   ]);
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
@@ -34,6 +36,7 @@ export default async function Page({
       learning={learning}
       hour12={hour12}
       contextLine={context?.copy ?? null}
+      lastSampleMs={freshness.lastSampleMs}
     />
   );
 }

--- a/app/(tabs)/radar/page.tsx
+++ b/app/(tabs)/radar/page.tsx
@@ -2,6 +2,7 @@ import { RadarShell } from "@/components/RadarShell";
 import { getSnapshot } from "@/lib/snapshot";
 import { mockAirborneSnapshot } from "@/lib/mock";
 import { getLearningState } from "@/lib/learning";
+import { getFreshness } from "@/lib/freshness";
 
 export const metadata = {
   title: "Radar",
@@ -16,11 +17,19 @@ export default async function RadarPage({
 }: {
   searchParams: SP;
 }) {
-  const [real, learning] = await Promise.all([
+  const [real, learning, freshness] = await Promise.all([
     getSnapshot(),
     getLearningState(),
+    getFreshness(),
   ]);
   const mockOn = searchParams.mock === "up";
   const initial = mockOn ? mockAirborneSnapshot(real) : real;
-  return <RadarShell initial={initial} mockOn={mockOn} learning={learning} />;
+  return (
+    <RadarShell
+      initial={initial}
+      mockOn={mockOn}
+      learning={learning}
+      lastSampleMs={freshness.lastSampleMs}
+    />
+  );
 }

--- a/components/FreshnessLabel.tsx
+++ b/components/FreshnessLabel.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SS_TOKENS } from "@/lib/tokens";
+import { STALE_MS } from "@/lib/freshness";
+
+type Props = {
+  /** ms-since-epoch of the last successful track sample. null = unknown. */
+  lastSampleMs: number | null;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export function FreshnessLabel({ lastSampleMs, className, style }: Props) {
+  // Re-tick every 30s so the label stays honest without requiring a
+  // server round-trip. The cookie/cache layer keeps the underlying value
+  // current at server-render time; this just ages it gracefully.
+  const [now, setNow] = useState<number>(() =>
+    typeof window === "undefined" ? lastSampleMs ?? 0 : Date.now(),
+  );
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!lastSampleMs) {
+    return (
+      <span
+        className={`ss-mono ${className ?? ""}`}
+        style={{ fontSize: 10, color: SS_TOKENS.fg2, ...style }}
+      >
+        LAST SAMPLE — UNKNOWN
+      </span>
+    );
+  }
+  const ageMs = Math.max(0, now - lastSampleMs);
+  const stale = ageMs > STALE_MS;
+  const m = Math.floor(ageMs / 60_000);
+  const label = m < 1 ? "JUST NOW" : `${m}m AGO`;
+  return (
+    <span
+      className={`ss-mono ${className ?? ""}`}
+      style={{
+        fontSize: 10,
+        color: stale ? SS_TOKENS.alert : SS_TOKENS.fg2,
+        letterSpacing: ".06em",
+        ...style,
+      }}
+      title={
+        stale
+          ? "Live cron may be down — last sample is older than 15 minutes."
+          : undefined
+      }
+    >
+      LAST SAMPLE — {label}
+    </span>
+  );
+}

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -16,6 +16,7 @@ import { PredictionCard } from "./PredictionCard";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import { Logo } from "./brand/Logo";
+import { FreshnessLabel } from "./FreshnessLabel";
 
 // Hide the activity strip when the most recent event is older than this —
 // a stale "Guardian One up · 8 hours ago" looks more like a bug than a
@@ -32,6 +33,9 @@ type Props = {
    *  ("usually up at this hour. 67% of weeks."). Server computes,
    *  passes the string in. null = hide. */
   contextLine?: string | null;
+  /** ms-since-epoch of the most recent track sample. null = no
+   *  meta:last_sample_ts in KV yet (renders "UNKNOWN"). */
+  lastSampleMs?: number | null;
 };
 
 export function Glanceable({
@@ -41,6 +45,7 @@ export function Glanceable({
   learning,
   hour12 = false,
   contextLine = null,
+  lastSampleMs = null,
 }: Props) {
   const snap = useAircraft(initial, mockOn);
   const [updatedAgo, setUpdatedAgo] = useState<number>(0);
@@ -199,6 +204,10 @@ export function Glanceable({
       {others.length > 0 && <Others others={others} />}
 
       <PredictionCard learning={learning} hour12={hour12} />
+
+      <div style={{ marginTop: 4, paddingLeft: 4 }}>
+        <FreshnessLabel lastSampleMs={lastSampleMs} />
+      </div>
 
       <Footer />
     </main>

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -12,6 +12,7 @@ import { SpottedButton } from "./SpottedButton";
 import { HotZoneLayer } from "./HotZoneLayer";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
+import { FreshnessLabel } from "./FreshnessLabel";
 import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
 import type { LearningState } from "@/lib/learning";
 
@@ -36,9 +37,16 @@ type Props = {
   initial: Snapshot;
   mockOn?: boolean;
   learning?: LearningState;
+  /** ms-since-epoch of the most recent track sample. null = unknown. */
+  lastSampleMs?: number | null;
 };
 
-export function RadarShell({ initial, mockOn = false, learning }: Props) {
+export function RadarShell({
+  initial,
+  mockOn = false,
+  learning,
+  lastSampleMs = null,
+}: Props) {
   const snap = useAircraft(initial, mockOn);
   const fleetMap = useMemo(
     () => new Map<string, FleetEntry>(snap.aircraft.map((a) => [a.tail, a])),
@@ -145,6 +153,23 @@ export function RadarShell({ initial, mockOn = false, learning }: Props) {
       </header>
 
       <CompassN />
+
+      <div
+        style={{
+          position: "absolute",
+          top: 60,
+          left: 12,
+          padding: "4px 8px",
+          borderRadius: 6,
+          background: "rgba(11,13,16,0.7)",
+          border: `.5px solid ${SS_TOKENS.hairline}`,
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
+          zIndex: 10,
+        }}
+      >
+        <FreshnessLabel lastSampleMs={lastSampleMs} />
+      </div>
 
       {airborne.length > 0 && <Carousel airborne={airborne} />}
 

--- a/lib/freshness.ts
+++ b/lib/freshness.ts
@@ -1,0 +1,46 @@
+// "How stale is the latest live track sample?" Single source of truth so
+// /radar and / can both render a LAST SAMPLE label that flips amber when
+// the cron silently dies. Without this, the UI keeps reporting state as
+// current even when the live poller has been down for hours.
+//
+// The writer is logTracks() in lib/tracks.ts (called from the live cron
+// on every successful snapshot). The reader is the home + radar pages.
+
+import { getRedis } from "./cache";
+
+export const LAST_SAMPLE_KEY = "meta:last_sample_ts";
+export const STALE_MS = 15 * 60 * 1000; // 15 min — should see a sample every ~60s when healthy
+
+export type Freshness = {
+  lastSampleMs: number | null;
+  ageMs: number | null;
+  isStale: boolean;
+};
+
+export async function getFreshness(): Promise<Freshness> {
+  const redis = await getRedis();
+  if (!redis) return { lastSampleMs: null, ageMs: null, isStale: false };
+  try {
+    const raw = await redis.get<string | number>(LAST_SAMPLE_KEY);
+    const lastSampleMs =
+      typeof raw === "number" ? raw : raw ? Number(raw) : null;
+    if (!lastSampleMs || !Number.isFinite(lastSampleMs)) {
+      return { lastSampleMs: null, ageMs: null, isStale: false };
+    }
+    const ageMs = Date.now() - lastSampleMs;
+    return { lastSampleMs, ageMs, isStale: ageMs > STALE_MS };
+  } catch {
+    return { lastSampleMs: null, ageMs: null, isStale: false };
+  }
+}
+
+/** Best-effort writer. Called from logTracks() on every snapshot. */
+export async function recordLastSample(tsMs: number): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) return;
+  try {
+    await redis.set(LAST_SAMPLE_KEY, tsMs);
+  } catch {
+    /* best-effort — non-fatal */
+  }
+}

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -10,6 +10,7 @@
 
 import { getRedis } from "./cache";
 import { recordFirstSampleIfMissing } from "./learning";
+import { recordLastSample } from "./freshness";
 import type { Snapshot } from "./types";
 
 export type TrackPoint = {
@@ -51,6 +52,10 @@ export async function logTracks(snap: Snapshot): Promise<void> {
   if (points.length > 0) {
     await recordFirstSampleIfMissing(new Date(snap.fetched_at));
   }
+  // Always update the freshness pointer so /radar + / can flip the LAST
+  // SAMPLE label amber when this cron silently dies. Best-effort; never
+  // throws.
+  await recordLastSample(snap.fetched_at);
 
   const writes = points.map(async (a) => {
     const key = `tracks:${a.tail}:${date}`;


### PR DESCRIPTION
## Summary

Per Roadmap **N7**. Catches the silent-cron-death failure mode: if the live poller stops writing to KV (OpenSky/adsb.fi shape change, KV write failure, anything), the UI keeps reporting state as current even when it's hours stale. Now both `/` and `/radar` carry a small `LAST SAMPLE — Xm AGO` label that flips amber after 15 minutes.

## What ships

- `lib/freshness.ts` — `getFreshness()` reads `meta:last_sample_ts`; `recordLastSample(tsMs)` writes it.
- `lib/tracks.ts` — `logTracks()` now calls `recordLastSample(snap.fetched_at)` on every snapshot. **One-line addition; this is the deny-list-blocked piece** (see below).
- `components/FreshnessLabel.tsx` — client component, re-ticks every 30s, amber after 15 min stale.
- `/radar` — small overlay in the top-left under the status pill.
- `/` — small mono label between `PredictionCard` and footer.

## Auto-merge gate result

**GATE FAILED → opens for review.**

Touches `lib/tracks.ts` which is in the deny-list. The full feature is shippable as one unit; needs a human read-through on the tracks.ts change (one new import + one `await recordLastSample(...)` call right next to the existing `recordFirstSampleIfMissing`). Without the writes-side, the label would show "UNKNOWN" forever.

## Verification

- `npx tsc --noEmit` clean
- `npm run build` clean
- 7 files, +159 / -4

🤖 Generated with [Claude Code](https://claude.com/claude-code)