### PR TITLE
fix(pwa): iOS standalone meta + a11y on /about embed

### DIFF
--- a/app/(tabs)/about/page.tsx
+++ b/app/(tabs)/about/page.tsx
@@ -410,6 +410,10 @@ function EmbedBadgeCallout() {
       </p>
       <pre
         className="ss-mono"
+        // tabIndex=0 so the horizontally-scrollable region is reachable
+        // by keyboard. axe scrollable-region-focusable rule.
+        tabIndex={0}
+        aria-label="SmokySignal embed badge HTML snippet"
         style={{
           background: SS_TOKENS.bg2,
           border: `.5px solid ${SS_TOKENS.hairline}`,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,6 +31,14 @@ export const metadata: Metadata = {
   description: DESCRIPTION,
   applicationName: "SmokySignal",
   manifest: "/manifest.json",
+  // iOS PWA standalone-mode flags. Without these the home-screen install
+  // launches in a degraded "kinda-Safari" shell — wrong status bar, no
+  // app-icon label fallback, brand voice broken on first paint.
+  appleWebApp: {
+    capable: true,
+    title: "SmokySignal",
+    statusBarStyle: "black-translucent",
+  },
   icons: {
     icon: [
       { url: "/icons/favicon.svg", type: "image/svg+xml" },


### PR DESCRIPTION
## Summary

Two small fixes from the P10 audit:

1. **iOS PWA standalone-mode meta** (`app/layout.tsx`) — adds `appleWebApp.{capable, title, statusBarStyle}` to Next.js Metadata. Without these, iOS A2HS launches in a degraded shell (white status bar, no enforced app name). `statusBarStyle: "black-translucent"` matches the brand `bg-0` (`#0B0D10`).
2. **a11y on `/about` embed `<pre>`** — `tabIndex={0}` + `aria-label`. Was the only P1 finding in the P10 audit (axe `scrollable-region-focusable`).

Manifest itself is already valid — all 4 icons 200, has maskable variants + theme/bg colors. Audit details: `/tmp/prompt10-pwa-audit.json`.

## Auto-merge gate

- ✓ 0 P0 / coherence; 1 P1 fixed in this PR
- ✓ Build clean
- ✓ Diff +12 lines, 2 files
- ✓ All paths allow-listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)