### PR TITLE
feat(about): campaign-hat + wordmark prominent in hero

### DIFF
--- a/app/(tabs)/about/page.tsx
+++ b/app/(tabs)/about/page.tsx
@@ -52,6 +52,16 @@ export default async function AboutPage() {
       </header>
 
       <Section eyebrow="What this is">
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            marginBottom: 18,
+            paddingTop: 8,
+          }}
+        >
+          <Logo size={80} wordmark />
+        </div>
         <p
           style={{
             fontSize: 22,


### PR DESCRIPTION
## Summary

Per Roadmap **N10**. `/about` "What this is" section was text-only above the fold. Adds the Logo (campaign hat + `SmokySignal` wordmark) at 80px centered above the headline. First thing a curious visitor sees is the brand mark.

`<Logo />` already supports `{size, wordmark}` — no new code, no new bytes.

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Build clean
- ✓ Diff +10 lines, 1 file
- ✓ Allow-listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)