### PR TITLE
fix(radar): heatmap readability — cap opacity, log-scale weight, zoom-aware paint

### DIFF
--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -178,17 +178,43 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
               visibility: enabledRef.current ? "visible" : "none",
             },
             paint: {
+              // log10(count) so a 100-sample cell isn't 100x as bright
+              // as a 1-sample cell. count=1 → weight 0.2, count=10 → 0.6,
+              // count=100 → 1.0. Diminishing returns past that.
               "heatmap-weight": [
                 "interpolate",
                 ["linear"],
-                ["get", "count"],
-                1,
+                ["log10", ["max", ["get", "count"], 1]],
+                0,
                 0.2,
-                20,
+                2,
                 1,
               ],
-              "heatmap-intensity": 1,
-              "heatmap-radius": 32,
+              // Pull intensity DOWN at low zoom so the regional view
+              // reads as a heatmap, not a region-wide alert.
+              "heatmap-intensity": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                7,
+                0.6,
+                11,
+                1,
+              ],
+              // Smaller radius at low zoom so cells don't merge into
+              // a continuous blob across all of Puget Sound.
+              "heatmap-radius": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                7,
+                14,
+                11,
+                28,
+              ],
+              // Dialed-back opacity stops — same hue progression as before
+              // but the top stop is 0.65 instead of 0.78, so dense areas
+              // remain readable instead of going solid red.
               "heatmap-color": [
                 "interpolate",
                 ["linear"],
@@ -196,15 +222,15 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
                 0,
                 "rgba(0,0,0,0)",
                 0.05,
-                "rgba(245,184,64,0.18)",
-                0.3,
-                "rgba(245,184,64,0.55)",
+                "rgba(245,184,64,0.15)",
+                0.35,
+                "rgba(245,184,64,0.45)",
                 0.7,
-                "rgba(245,140,40,0.70)",
+                "rgba(245,140,40,0.55)",
                 1.0,
-                "rgba(220,38,38,0.78)",
+                "rgba(220,38,38,0.65)",
               ],
-              "heatmap-opacity": 0.85,
+              "heatmap-opacity": 0.7,
             },
           },
           beforeId,


### PR DESCRIPTION
## Summary

Per Roadmap **N11**. Alex flagged: "solid red chunk Edmonds to Eatonville." Audit at `/tmp/prompt10-heatmap-tuning.md` traced it to three reinforcing causes:

1. **`heatmap-weight` saturated at count=20** — undersized 5x vs actual 100+ counts in WSP-fixed-wing cells. Switched to `log10(count)` with weight 0.2 at count=1, 1.0 at count=100, diminishing past.
2. **`heatmap-radius` fixed at 32px regardless of zoom** — at zoom ≤8 the halo covers ~10nm and adjacent saturated cells visually merge. Now interpolates 14px → 28px across zoom 7→11.
3. **Top color stop too opaque** — `rgba(220,38,38,0.78)` with layer opacity `0.85` = ~66% effective. Pulled top stop to `0.65` and layer opacity to `0.7`.

Bonus: `heatmap-intensity` zoom-scaled (0.6 at zoom 7 → 1.0 at zoom 11) so regional view reads as a heatmap, not a region-wide alert.

## Tradeoff

The new config is conservative globally, not just at high data volumes. Lightly-used areas will look lighter too. If that reads too soft, one-line revert via the `heatmap-opacity` stop.

## Auto-merge gate

- ✓ 0 P0 / P1 / coherence
- ✓ Build clean
- ✓ Diff +37 / -11, 1 file
- ✓ Allow-listed (`components/HotZoneLayer.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)