### PR TITLE
feat(regions): rider region selector — Puget Sound / counties / All WA

### DIFF
--- a/components/RadarMap.tsx
+++ b/components/RadarMap.tsx
@@ -16,6 +16,7 @@ import {
   glyphRoleFor,
   type GlyphRole,
 } from "@/lib/brand/aircraft-glyphs";
+import { REGIONS, type RegionId } from "@/lib/regions";
 
 const PUGET_SOUND: [number, number] = [-122.3, 47.6];
 const DEFAULT_ZOOM = 9;
@@ -101,11 +102,16 @@ export default function RadarMap({
   aircraft,
   rider,
   showDistanceRings = false,
+  regionId,
   onMapReady,
 }: {
   aircraft: Aircraft[];
   rider: RiderPos | null;
   showDistanceRings?: boolean;
+  /** Pivots the map view between Puget Sound / counties / All-WA.
+   *  When undefined or "puget_sound", no flyTo — preserves the
+   *  existing rider-zoom + auto-recenter behavior. */
+  regionId?: RegionId;
   onMapReady?: (map: MaplibreMap | null) => void;
 }) {
   const router = useRouter();
@@ -323,6 +329,29 @@ export default function RadarMap({
       /* layer not yet attached */
     }
   }, [showDistanceRings]);
+
+  // When the rider changes region (Puget Sound → Spokane etc), fly the
+  // map to the region's centroid + default zoom. Skipped on initial
+  // mount where regionId starts at "puget_sound" — that's the existing
+  // default and a flyTo would feel like a flicker.
+  const lastRegionRef = useRef<RegionId | undefined>(regionId);
+  useEffect(() => {
+    if (!regionId || regionId === lastRegionRef.current) return;
+    lastRegionRef.current = regionId;
+    const map = mapRef.current;
+    if (!map || !readyRef.current) return;
+    const r = REGIONS[regionId];
+    if (!r) return;
+    map.flyTo({
+      center: [r.centerLon, r.centerLat],
+      zoom: r.zoomLevel,
+      duration: 800,
+    });
+    // Mark that the user "interacted" so the auto-recenter loop pauses
+    // for 15s — otherwise the next 5s tick would yank them back to
+    // their geolocation and undo the region pivot.
+    userInteractedAtRef.current = Date.now();
+  }, [regionId]);
 
   // Auto-recenter every 5s, paused for 15s after the user pans or zooms.
   useEffect(() => {

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -13,6 +13,9 @@ import { HotZoneLayer } from "./HotZoneLayer";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import { FreshnessLabel } from "./FreshnessLabel";
+import { RegionSelector } from "./RegionSelector";
+import { REGION_CHANGE_EVENT, getRegion } from "@/lib/region-pref";
+import type { RegionId } from "@/lib/regions";
 import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
 import type { LearningState } from "@/lib/learning";
 
@@ -69,10 +72,18 @@ export function RadarShell({
   const [toast, setToast] = useState<string | null>(null);
   const [map, setMap] = useState<MaplibreMap | null>(null);
   const [showRings, setShowRings] = useState(false);
-  // Hydrate the rings pref from localStorage on mount.
+  const [regionId, setRegionId] = useState<RegionId>("puget_sound");
+  // Hydrate the rings pref + region from localStorage on mount.
   useEffect(() => {
     if (typeof window === "undefined") return;
     setShowRings(window.localStorage.getItem("ss_distance_rings_visible") === "1");
+    setRegionId(getRegion());
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ id: RegionId }>).detail;
+      setRegionId(detail?.id ?? getRegion());
+    };
+    window.addEventListener(REGION_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(REGION_CHANGE_EVENT, onChange);
   }, []);
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -113,6 +124,7 @@ export function RadarShell({
         aircraft={airborne}
         rider={rider}
         showDistanceRings={showRings}
+        regionId={regionId}
         onMapReady={setMap}
       />
       <HotZoneLayer
@@ -158,24 +170,27 @@ export function RadarShell({
           big
           tooltip={pillTooltip}
         />
-        <Tooltip
-          side="bottom"
-          align="end"
-          content="How many of our 16 tracked tails are up right now."
-        >
-          <span
-            className="ss-mono"
-            tabIndex={0}
-            style={{
-              fontSize: 10.5,
-              color: counterColor,
-              letterSpacing: ".06em",
-              cursor: "help",
-            }}
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <RegionSelector />
+          <Tooltip
+            side="bottom"
+            align="end"
+            content="How many of our 16 tracked tails are up right now."
           >
-            {airborne.length}/{total} UP
-          </span>
-        </Tooltip>
+            <span
+              className="ss-mono"
+              tabIndex={0}
+              style={{
+                fontSize: 10.5,
+                color: counterColor,
+                letterSpacing: ".06em",
+                cursor: "help",
+              }}
+            >
+              {airborne.length}/{total} UP
+            </span>
+          </Tooltip>
+        </div>
       </header>
 
       <CompassN />

--- a/components/RegionSelector.tsx
+++ b/components/RegionSelector.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+// Compact dropdown that lets the rider pivot the radar viewport
+// between Puget Sound (default) / Pierce / Snohomish / Spokane / All
+// Washington. Persists to localStorage; other components subscribe to
+// the same CustomEvent so the map flies on change.
+
+import { useEffect, useState } from "react";
+import { REGIONS, type RegionId } from "@/lib/regions";
+import {
+  REGION_CHANGE_EVENT,
+  getRegion,
+  setRegion,
+} from "@/lib/region-pref";
+import { SS_TOKENS } from "@/lib/tokens";
+
+type Props = {
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export function RegionSelector({ className, style }: Props) {
+  const [current, setCurrent] = useState<RegionId>(() => getRegion());
+
+  useEffect(() => {
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ id: RegionId }>).detail;
+      setCurrent(detail?.id ?? getRegion());
+    };
+    window.addEventListener(REGION_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(REGION_CHANGE_EVENT, onChange);
+  }, []);
+
+  return (
+    <select
+      value={current}
+      onChange={(e) => setRegion(e.target.value as RegionId)}
+      aria-label="Region"
+      className={`ss-mono ${className ?? ""}`}
+      style={{
+        fontSize: 11,
+        background: "rgba(11,13,16,0.78)",
+        color: SS_TOKENS.fg0,
+        border: `.5px solid ${SS_TOKENS.hairline2}`,
+        borderRadius: 6,
+        padding: "4px 8px",
+        backdropFilter: "blur(8px)",
+        WebkitBackdropFilter: "blur(8px)",
+        cursor: "pointer",
+        ...style,
+      }}
+    >
+      {Object.values(REGIONS).map((r) => (
+        <option key={r.id} value={r.id}>
+          {r.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/lib/region-pref.ts
+++ b/lib/region-pref.ts
@@ -1,0 +1,32 @@
+// Localstorage-backed rider region preference. No accounts, no
+// server state. Other client components react to changes via the
+// "ss-region-change" CustomEvent.
+
+"use client";
+
+import { DEFAULT_REGION, REGIONS, type RegionId } from "./regions";
+
+const KEY = "ss_region_pref";
+export const REGION_CHANGE_EVENT = "ss-region-change";
+
+export function getRegion(): RegionId {
+  if (typeof window === "undefined") return DEFAULT_REGION;
+  try {
+    const v = window.localStorage.getItem(KEY) as RegionId | null;
+    return v && v in REGIONS ? v : DEFAULT_REGION;
+  } catch {
+    return DEFAULT_REGION;
+  }
+}
+
+export function setRegion(id: RegionId): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, id);
+    window.dispatchEvent(
+      new CustomEvent(REGION_CHANGE_EVENT, { detail: { id } }),
+    );
+  } catch {
+    /* localStorage may be disabled in some contexts (private mode) */
+  }
+}

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -1,0 +1,60 @@
+// Canonical region definitions for the radar/heat-map view. Used by
+// the rider-side region selector to pivot the map without rewiring the
+// data pipeline. The aggregator's geo-fence (lib/hotzones.ts) still
+// runs at server scope; per-region heat-map filtering is a follow-up
+// once the API supports it.
+
+export type RegionId =
+  | "puget_sound"
+  | "pierce"
+  | "snohomish"
+  | "spokane"
+  | "all_wa";
+
+export type Region = {
+  id: RegionId;
+  label: string;
+  centerLat: number;
+  centerLon: number;
+  zoomLevel: number;
+};
+
+export const REGIONS: Record<RegionId, Region> = {
+  puget_sound: {
+    id: "puget_sound",
+    label: "Puget Sound",
+    centerLat: 47.6,
+    centerLon: -122.3,
+    zoomLevel: 9,
+  },
+  pierce: {
+    id: "pierce",
+    label: "Pierce County",
+    centerLat: 47.05,
+    centerLon: -122.3,
+    zoomLevel: 10,
+  },
+  snohomish: {
+    id: "snohomish",
+    label: "Snohomish County",
+    centerLat: 48.0,
+    centerLon: -121.9,
+    zoomLevel: 10,
+  },
+  spokane: {
+    id: "spokane",
+    label: "Spokane",
+    centerLat: 47.66,
+    centerLon: -117.43,
+    zoomLevel: 10,
+  },
+  all_wa: {
+    id: "all_wa",
+    label: "All Washington",
+    centerLat: 47.4,
+    centerLon: -120.5,
+    zoomLevel: 7,
+  },
+};
+
+export const DEFAULT_REGION: RegionId = "puget_sound";


### PR DESCRIPTION
## Summary

Per Roadmap **N8**. Compact dropdown in the `/radar` header lets the rider pivot the map between Puget Sound (default), Pierce County, Snohomish County, Spokane, or All Washington. No accounts, no server state — pref lives in `localStorage.ss_region_pref`.

## Architecture

| File | Role |
|---|---|
| `lib/regions.ts` | Canonical region defs (centroid + default zoom) |
| `lib/region-pref.ts` | `get/set` + `CustomEvent` fan-out for cross-component reactivity (`ss-region-change`) |
| `components/RegionSelector.tsx` | Dropdown UI; listens to the event so multiple selectors stay in sync |
| `components/RadarShell.tsx` | Hydrates region from localStorage, threads `regionId` prop into `RadarMap` |
| `components/RadarMap.tsx` | `flyTo` on region change (800ms ease); marks interaction so the 5s auto-recenter loop doesn't yank the user back |

## Out of scope (follow-up)

**Heat-map data per-region filter** is not in this PR. The selector changes the MAP VIEW; the heat data is still scoped to whatever `lib/hotzones.ts` returns (currently Puget Sound after PR #27 lands). Until the API supports per-region filtering, switching to "Spokane" reframes the radar viewport but you'll see the same Puget Sound heatmap. The Phase 2.1 Nashville fix (`lib/hotzones.ts`, deny-listed) is the prerequisite — once it's merged + extended for per-region bounds, the heat re-aims.

## Auto-merge gate

**LIKELY GATE FAILED on diff size.** 5 files, +200ish lines. Multi-file feature; opens for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)