### PR TITLE
docs(roadmap): mark P9/P10 shipped + add new items from rider-meet

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,22 +42,36 @@ needle vs which ones risk pulling it off-brand or out of scope.
 Side-project-sized work. Effort XS or S, no major brand tension, concrete
 user value visible at first paint.
 
-### N1. Speed-warning UI ships
-- **Description:** The `warn` token (`#FF7A1A`) is reserved in `lib/tokens.ts`
-  but unused. Per BRAND.md §3, the canonical warning copy already exists:
-  `EASE OFF — bird 4mi out, you're 7 over.` Wire it: the rider's GPS speed
-  vs `entry.altitude_ft`-derived distance vs `getSpeedWarningEnabled()`
-  flag (already in `lib/flags.ts`).
-- **Why it matters:** This is the headline feature in the product
-  description and it's the one thing that's still vaporware. Until it
-  ships, "SmokySignal warns you when you're speeding under the bird" is
-  marketing copy, not behavior.
+### N1a. Speed-warning DRY-RUN logging
+- **Description:** Wire the speed-warning trigger logic without surfacing
+  any UI. When the rider's speed exceeds the limit AND inside an active
+  hot zone AND a tracked plane is airborne within 5nm, fire a
+  `console.log` (and optionally a fetch to `/api/spot` with a `dry-run=1`
+  flag) so we can collect data on how often the trigger would fire and
+  on what cadence — without false-alarming any rider.
+- **Why it matters:** The threshold calculus is brand-critical. False
+  alarms on cruise-control are worse than no warnings. Dry-run gives us
+  a week of trigger-rate data before we surface anything user-visible.
 - **Effort:** S
-- **Risk:** med — the warning UX is brand-critical; getting the threshold
-  calculus wrong means false-alarming a rider on cruise control.
-- **Brand tension:** none — `warn` is reserved exactly for this.
-- **Dependencies:** none, all primitives exist.
-- **Status:** ready to write a prompt.
+- **Risk:** low — no UI, no notifications, just instrumented logging.
+- **Brand tension:** none.
+- **Dependencies:** posted-speed-limit data source + hot-zone
+  proximity helper (neither currently exist; both must be designed
+  first). DEFERRED in P9.
+- **Status:** blocked on dependencies; needs a focused-session prompt.
+
+### N1b. Speed-warning UI surface
+- **Description:** Once N1a's data confirms the trigger threshold is
+  sane, surface the canonical warning (`EASE OFF — bird Xmi out, you're
+  Y over.`) full-screen with the reserved `--warn` token (`#FF7A1A`).
+- **Why it matters:** This is the headline feature; once the threshold
+  is data-validated, it's safe to ship.
+- **Effort:** S
+- **Risk:** med — brand-critical UX.
+- **Brand tension:** none — `warn` is reserved.
+- **Dependencies:** N1a (need 5–7 days of dry-run data to set the
+  threshold).
+- **Status:** queued behind N1a.
 
 ### N2. adsb.fi historical backfill
 - **Description:** OpenSky's historical-tracks endpoint is broken (was the
@@ -75,7 +89,7 @@ user value visible at first paint.
   attribution required — already in our footer).
 - **Status:** ready to write a prompt.
 
-### N3. FAA registration deep-link on `/plane/[tail]`
+### N3. FAA registration deep-link on `/plane/[tail]` ✓ SHIPPED (P9 #16)
 - **Description:** Add a small "FAA registry →" mono link next to the
   existing `ICAO24` line on the plane detail page that points at
   `https://registry.faa.gov/aircraftinquiry/Search/NNumberResult?nNumberTxt={tail}`.
@@ -90,7 +104,7 @@ user value visible at first paint.
 - **Dependencies:** none.
 - **Status:** ready to write a prompt.
 
-### N4. Vercel deploy-failure cron + email alert
+### N4. Vercel deploy-failure cron + email alert ✓ SHIPPED (P9 #18)
 - **Description:** Small GitHub Action (or Vercel Cron) that hits
   `vercel deployments list` hourly, surfaces any failed prod deploys to
   the commit author by email. We discussed this when Vercel kept biting us
@@ -104,7 +118,7 @@ user value visible at first paint.
 - **Dependencies:** GitHub Action runs free; email is built-in.
 - **Status:** ready to write a prompt.
 
-### N5. Color-contrast cleanup pass
+### N5. Color-contrast cleanup pass ✓ SHIPPED (P9 #21)
 - **Description:** PR #9 fixed `--ss-fg2`. PR #13 fixed `SS_TOKENS.fg3`
   on the plane page. Audit the rest of the codebase for hardcoded greys
   or further `fg3` usage that fails AA. Single-PR sweep.
@@ -119,7 +133,7 @@ user value visible at first paint.
 - **Dependencies:** none.
 - **Status:** ready to write a prompt.
 
-### N6. README + README-style HOW_TO_HAND_OFF cleanup
+### N6. README + README-style HOW_TO_HAND_OFF cleanup ✓ SHIPPED (P9 #15)
 - **Description:** The repo's `README.md` is the design-handoff doc from
   pre-build. It's accurate but reads as a spec, not as a "how to run this
   project" doc. Add a short "Working with this codebase" section that
@@ -133,6 +147,79 @@ user value visible at first paint.
 - **Brand tension:** none.
 - **Dependencies:** none.
 - **Status:** ready to write a prompt.
+
+### N7. Data freshness indicator ✓ SHIPPED (P9 #22)
+- **Description:** `LAST SAMPLE — Xm AGO` mono label on `/` and
+  `/radar`. Flips amber after 15 min stale. Catches silent-cron-death
+  failure mode before riders see hours-stale state as current.
+- **Status:** Live. Reads `meta:last_sample_ts`; `lib/tracks.ts`
+  writes it on every snapshot.
+
+### N8. Region selector (Puget Sound / counties / All WA)
+- **Description:** Dropdown in `/radar` header letting riders pivot
+  the map between Puget Sound (default), Pierce / Snohomish / Spokane
+  counties, or All Washington. Localstorage-backed pref, no accounts.
+  Map flies to the chosen region; heat-map data per-region filter is
+  follow-up (needs `lib/hotzones.ts` extension).
+- **Why it matters:** Single biggest UX upgrade in P10. Riders
+  outside Puget Sound (Spokane in particular) couldn't see their
+  area until this shipped.
+- **Effort:** M
+- **Risk:** low.
+- **Brand tension:** none.
+- **Status:** in-flight as P10 PR #28 (gate failed on size, awaiting
+  review).
+
+### N9. Auto-zoom radar to rider's location ✓ SHIPPED (P10 #25)
+- **Description:** First time geolocation resolves on `/radar`,
+  `flyTo` rider position at zoom 11 (street-level). One-shot — the
+  existing 5s recenter loop maintains center after that without
+  changing zoom. Skipped if user already manually panned/zoomed.
+- **Status:** Live. Tacoma riders open to Tacoma instead of the
+  regional Puget Sound overview.
+
+### N10. /about hero branding ✓ SHIPPED (P10 #24)
+- **Description:** `<Logo wordmark size={80}>` centered above the
+  "Truckers called them Smokey" headline. The campaign hat + wordmark
+  is the first thing a curious visitor sees.
+- **Status:** Live.
+
+### N11. Heat-map mobile readability ✓ SHIPPED (P10 #26)
+- **Description:** Three reinforcing fixes for "solid red chunk
+  Edmonds to Eatonville": log-scale weight (was linear capped at 20),
+  zoom-aware radius (14→28px across zoom 7→11), zoom-aware intensity
+  (0.6 at zoom 7), top-stop opacity dropped to 0.65 (was 0.78), layer
+  opacity to 0.7 (was 0.85). Audit details:
+  `/tmp/prompt10-heatmap-tuning.md`.
+- **Status:** Live.
+
+### N12. PWA install reliability ✓ SHIPPED (P10 #23)
+- **Description:** `appleWebApp.{capable, title, statusBarStyle}`
+  added to Next.js Metadata so iOS A2HS launches in a proper
+  standalone shell (matched-color status bar, enforced app name).
+  Also tabIndex=0 + aria-label on the /about embed `<pre>` block
+  (P1 a11y in the audit). Manifest itself was already valid.
+- **Status:** Live.
+
+### N13. Nashville geo-fence (hot-zones aggregator)
+- **Description:** Tighten `inRegion()` bounding box from "whole-state"
+  (45–49.5°N, -125 to -116°W) to Puget-Sound-tight (default 47.6,
+  -122.3, 80nm). Envvar-overridable: `SS_REGION_LAT/LON/NM`. Audit
+  found WSP Smokey 3 (N2446X) had ~1028 eastern-WA samples polluting
+  the heatmap. Details: `/tmp/prompt10-nashville-investigation.json`.
+- **Effort:** XS (1 file, +21/-6).
+- **Risk:** low.
+- **Brand tension:** none.
+- **Status:** in-flight as P10 PR #27 (`lib/hotzones.ts` is
+  deny-listed for auto-merge — manual review required).
+
+### N14. Historical context line on home ✓ SHIPPED (P9 #20)
+- **Description:** Mono caption under the Hero pill telling the
+  rider how the current hour-of-week reads historically: "usually up
+  at this hour. 67% of weeks." / "unusual hour. up only 12% of
+  weeks." / "usually up by now. running late tonight." / "quiet hour.
+  usually clear."
+- **Status:** Live. Hides cleanly when predictor is still learning.
 
 ## Tier 2 — Next (Q3 2026)
 
@@ -211,7 +298,7 @@ tradeoff conversation. New infra OK if it's commodity.
 - **Dependencies:** push pipeline (already shipped).
 - **Status:** ready to write a prompt.
 
-### NX5. Embeddable status badge for third-party sites
+### NX5. Embeddable status badge for third-party sites ✓ SHIPPED (P9 #17)
 - **Description:** Same `/api/badge.svg` we already serve, but documented +
   packaged + with a public "embed code" snippet on `/about`. Local moto
   blogs and rider forums could embed "is Smokey up right now?" on their
@@ -225,7 +312,7 @@ tradeoff conversation. New infra OK if it's commodity.
 - **Dependencies:** none.
 - **Status:** ready to write a prompt.
 
-### NX6. Distance rings on radar
+### NX6. Distance rings on radar ✓ SHIPPED (P9 #19)
 - **Description:** Optional toggleable concentric rings around the rider's
   current location at 5/10/15 mile increments. Helps riders read at a
   glance how close the bird actually is.
@@ -253,6 +340,94 @@ tradeoff conversation. New infra OK if it's commodity.
 - **Dependencies:** none.
 - **Status:** decide whether federation is real ambition (T3) before
   taking this on.
+
+### NX8. Time-scrubber for historical playback on `/radar`
+- **Description:** Promoted from L7 → NX. A scrub bar at the bottom
+  of `/radar` letting the rider drag through the last 24 hours of
+  fleet positions. "Where was Smokey at 3pm yesterday?"
+- **Why it matters:** Most-requested feature in similar projects;
+  data already exists in `tracks:*` keys. Promoting from Later → Next
+  because the lift is mostly UI on data we already have.
+- **Effort:** L — UI-heavy, careful state management for the map
+  layer + smooth scrub interaction.
+- **Risk:** med — performance on mobile with large polylines.
+- **Brand tension:** none.
+- **Dependencies:** none.
+- **Status:** ready to design.
+
+### NX9. Mobile-specific heat-map paint strategy
+- **Description:** N11 tuned the heatmap globally for readability.
+  NX9 considers a *different* paint config at small viewports — e.g.
+  smaller radius below 480px, lighter opacity stops on Retina-scale
+  pixel-density. Distinct from N11 because that change applies
+  everywhere, not just mobile.
+- **Why it matters:** The Edmonds-to-Eatonville saturation that
+  prompted N11 was specifically a mobile complaint. If N11's global
+  tuning over-corrects for desktop, NX9 lets us split the
+  difference.
+- **Effort:** S
+- **Risk:** low.
+- **Brand tension:** none.
+- **Dependencies:** observe N11 in the wild for a week first.
+- **Status:** ship-and-iterate; only build if N11 needs more work.
+
+### NX10. Premium tier without accounts
+- **Description:** Stripe Checkout for either (a) one-time tip
+  donation or (b) recurring "Smokey Plus" tier with a single benefit
+  (custom corridor alerts, longer flight-history retention, or
+  early access to new regions). NO ACCOUNTS — Stripe Customer ID
+  in localStorage; rider can restore by entering their email.
+- **Why it matters:** Cost ceiling rising as data + Vercel + MapTiler
+  usage grows. Even token monetization changes the math from "Alex
+  eating cost forever" to "self-sustaining."
+- **Effort:** M — Stripe integration well-trodden; the harder
+  question is the brand-voice copy for an upsell.
+- **Risk:** med — introduces customer-support burden.
+- **Brand tension:** meaningful — the brand has zero pretension
+  and zero upsell language. Copy must match existing voice ("Buy
+  us a coffee, we'll keep listening." not "Upgrade for premium
+  features.")
+- **Dependencies:** Alex's monetization-stance decision (see Open
+  Questions).
+- **Status:** worth a focused tradeoff prompt; defer until
+  cost becomes a real constraint.
+
+### NX11. Ground-patrol awareness
+- **Description:** Surface awareness of marked WSP cars / sheriff
+  patrol cars on a separate alert layer. Possible data sources:
+  Waze API (proprietary), public scanner integrations (legally
+  fraught), user-spotted reports via a community Spot button
+  (slow but trustable).
+- **Why it matters:** The "Smoky AND coppers" idea — riders care
+  about ground patrol as much as air patrol. The product brand
+  ("the bird") is air-only; expanding to ground is a meaningful
+  scope change.
+- **Effort:** L — mostly research-first (data source viability),
+  then UI integration.
+- **Risk:** high — privacy + legal questions around scanner data;
+  brand-scope creep.
+- **Brand tension:** major — "the bird is up" is the entire
+  product positioning. Ground-patrol awareness is a different
+  product wearing the same brand.
+- **Dependencies:** data-source research.
+- **Status:** research-first, decide after.
+
+### NX12. Predictor algorithm tuning
+- **Description:** `lib/predictor.ts` could use historical-pattern
+  weighting (recent weeks count more than 30-day-old) and tighter
+  hour buckets (15-min instead of 60-min). Confidence model could
+  factor weather, day-of-week clustering, and seasonal patterns.
+- **Why it matters:** The current predictor works ("3pm Friday
+  is usually busy"). Tuning makes it sharper ("3:15pm Fridays are
+  particularly busy in summer rush").
+- **Effort:** L — algorithm work; needs clear evaluation criteria
+  before tuning.
+- **Risk:** low — the existing model still works; this is
+  refinement.
+- **Brand tension:** none.
+- **Dependencies:** evaluation harness (synthetic test against
+  known-good predictions).
+- **Status:** focused-session topic, not a tactical fix.
 
 ## Tier 3 — Later (Q4 2026 onward)
 
@@ -360,18 +535,8 @@ tradeoff is worth surfacing. Native shells, federation, paid tiers.
 - **Status:** consider only after the federation work.
 
 ### L7. Time-scrubber for historical playback on `/radar`
-- **Description:** A scrub bar at the bottom of `/radar` that lets the
-  rider drag through the last 24 hours of fleet positions. "Where was
-  Smokey at 3pm yesterday?"
-- **Why it matters:** The historical data exists (`tracks:*` keys); we
-  just don't expose it as a timeline. This is one of the most-requested
-  features in similar projects.
-- **Effort:** L — UI-heavy, requires careful state management on the map
-  layer + a smooth scrub interaction.
-- **Risk:** med — performance on mobile with large polylines is the gotcha.
-- **Brand tension:** none.
-- **Dependencies:** none beyond what's already in KV.
-- **Status:** good Q4 candidate.
+
+PROMOTED to NX8 in P10. See Tier 2.
 
 ### L8. PMTiles self-hosting
 - **Description:** Replace MapTiler-served vector tiles with self-hosted
@@ -437,14 +602,17 @@ because the boundaries are clear.
   The voice-guardian skill exists to catch slips, not to scale generation.
 - **What would change our mind:** Nothing. Voice is human work.
 
-### MN5. Mainstream press push / app-store launch
+### MN5. Mainstream tech press push / App Store featuring
 - **Description:** Submit the app to TechCrunch, get reviewed in Wired,
-  push for App Store featuring.
+  push for App Store featuring. (Distinct from posting in
+  `/r/motorcycles`, podcasts, or local rider community channels — those
+  are welcome and fall under organic word-of-mouth.)
 - **Why we say no:** Fundamental scale mismatch. The codebase is hosted on
   Vercel free tier. The data sources are rate-limited free APIs. A
-  TechCrunch wave would 503 us inside an hour and then we'd be paying
-  enterprise tier on every dependency. The product is right-sized for the
-  rider community that finds it through word of mouth.
+  TechCrunch wave would 503 us inside an hour and we'd be paying
+  enterprise tier on every dependency. The product is right-sized for
+  the rider community that finds it through word of mouth — that audience
+  IS welcome and not what this rejection is about.
 - **What would change our mind:** A funded scaling plan + clear monetization.
   Unlikely at side-project scale.
 
@@ -474,6 +642,49 @@ because the boundaries are clear.
   "we listen, we don't talk." Recording riders' tracks server-side breaks
   that promise even if we encrypt and never look. Local-only storage might
   be OK but adds complexity for a feature riders can do better in Strava.
+
+### MN9. Real-time mainstream-press / Twitter-X virality push
+- **Description:** Same as MN5 specifically calling out
+  Twitter/X virality and "viral on Hacker News" goals.
+- **Why we say no:** Same scale-mismatch reasoning as MN5. A
+  viral spike has the same effect as a mainstream press wave —
+  503 in an hour, enterprise-tier bills the next day. Riders
+  finding it via the rider community is the right discovery
+  path; a viral spike is a mismatched audience anyway (most
+  viewers won't ride).
+- **What would change our mind:** Same as MN5 — funded scaling
+  plan + monetization.
+
+### MN10. User-uploaded plane photos / spotter leaderboard
+- **Description:** Reaffirms MN3. Riders submit photos of
+  spotted aircraft + a leaderboard ranks the top spotters.
+- **Why we say no:** BRAND.md §8 explicitly refuses depicting
+  authority. A scoreboard introduces "evade enforcement" framing.
+  See MN3 for the full refusal.
+
+## Why this exists when FlightRadar24 covers the data
+
+A common question. The answer is **curation + context + voice**, not
+data.
+
+| What FR24 does | What SmokySignal does |
+|---|---|
+| Shows everything that flies | Shows only enforcement-relevant aircraft |
+| General-purpose | Rider-specific (status pill, hot zones, role-aware copy) |
+| "See all aviation" brand | "Is the bird up?" brand |
+| Aircraft + position | Aircraft + position + pattern + context (historical-context line, freshness label, learning state) |
+| Subscription model with tiered features | Free, no-account, single-purpose |
+
+FR24's data quality + breadth is unmatched. We don't try to outdata
+them. The product's value is the **curation** (16 specific tails, not
+40,000) and the **voice** (laconic, dark, "Channel 19's tuning in"
+not "Track every aircraft"). A rider checking SmokySignal at a
+stoplight gets one answer in one second — they'd need 30 seconds
++ knowledge of the WSP tail registry to extract the same answer
+from FR24.
+
+If a competitor with FR24's data also nails the curation and voice,
+that's a real threat. Until then, the moat is editorial.
 
 ## Tradeoff conversations worth having
 
@@ -607,3 +818,21 @@ The autonomous prompts in `Prompts/` already encode the working pattern
 ## Revision history
 
 - 2026-05-02: Initial roadmap, generated by Prompt 8.
+- 2026-05-02 (later): Post-P9/P10 update —
+  - Marked N3, N4, N5, N6, N7, N14 (cool feature historical-context),
+    NX5, NX6 as ✓ SHIPPED via Prompt 9.
+  - Marked N9, N10, N11, N12 as ✓ SHIPPED via Prompt 10.
+  - Marked N13 (Nashville geo-fence) and N8 (region selector) as
+    in-flight via Prompt 10 (both gate-failed for legitimate reasons,
+    awaiting manual review).
+  - Split N1 → N1a (DRY-RUN) + N1b (UI surface). N1a deferred pending
+    posted-speed-limit + hot-zone-proximity primitives.
+  - Promoted L7 (time-scrubber) → NX8.
+  - Added NX9 (mobile-specific heat-map paint), NX10 (premium tier),
+    NX11 (ground-patrol awareness), NX12 (predictor tuning).
+  - Added MN9 (Twitter-X virality push), MN10 (spotter leaderboard
+    reaffirmed).
+  - Added "Why this exists when FlightRadar24 covers the data"
+    section.
+  - Tightened MN5 wording to distinguish mainstream tech press from
+    rider-community press (welcome).


### PR DESCRIPTION
## Summary

Per Prompt 10 Phase 4. Updates the autogenerated roadmap to reflect what shipped vs what's in flight, and folds in the new items from the rider-meet conversation that prompted P10.

## Shipped tags applied

**P9** (already merged): N3, N4, N5, N6, N7, N14 (historical-context cool feature), NX5, NX6

**P10** (this prompt): N9, N10, N11, N12

## In-flight, awaiting manual review

- **N8** region selector (PR #28) — gate failed on size (5 files / +214 lines)
- **N13** Nashville geo-fence (PR #27) — gate failed because `lib/hotzones.ts` is in deny-list

## New items added

| ID | Title |
|---|---|
| N8 | Region selector |
| N9 | Auto-zoom radar to rider |
| N10 | `/about` hero branding |
| N11 | Heat-map mobile readability |
| N12 | PWA install reliability |
| N13 | Nashville geo-fence |
| N14 | Historical-context line on home |
| NX9 | Mobile-specific heat-map paint |
| NX10 | Premium tier without accounts |
| NX11 | Ground-patrol awareness |
| NX12 | Predictor algorithm tuning |
| MN9 | Viral-push refusal |
| MN10 | Spotter leaderboard reaffirmed |

## Restructures

- **N1 split** → N1a (DRY-RUN) + N1b (UI surface). N1a deferred per P9 scoping.
- **L7 promoted** → NX8 (time-scrubber for historical playback).
- **MN5 tightened** to distinguish mainstream tech press (refused) from rider-community press (welcome).

## New section

**"Why this exists when FlightRadar24 covers the data"** — addresses the question Alex flagged at the rider meet. Short answer: differentiation is curation + context + voice, not data.

## Manual merge

Per `smokysignal-ship-it` discipline + Prompt 10 spec, this PR is **NOT auto-merged**. Roadmap revisions are judgment-heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)