### PR TITLE
feat(dash): restore /dash in tab bar, drop Speedometer

### DIFF
--- a/components/DashShell.tsx
+++ b/components/DashShell.tsx
@@ -6,17 +6,15 @@ import { useAircraft } from "@/lib/hooks/useAircraft";
 import { useRiderPos } from "@/lib/hooks/useRiderPos";
 import { SS_TOKENS } from "@/lib/tokens";
 import { SMOKY_TAIL } from "@/lib/seed";
-import { haversineNm, DEFAULT_SPEED_LIMIT_MPH } from "@/lib/geo";
+import { haversineNm } from "@/lib/geo";
 import { StatusPill } from "./StatusPill";
 import { Card } from "./Card";
-import { Speedometer } from "./Speedometer";
 import { AlertsOptInCard } from "./AlertsOptInCard";
 import type { Aircraft, Snapshot } from "@/lib/types";
 import type { ActivityEntry } from "@/lib/activity";
 
 const TABBAR_HEIGHT = 66;
 const NEAR_NM = 5;
-const MPS_TO_MPH = 2.236936;
 
 type Props = {
   initial: Snapshot;
@@ -26,7 +24,7 @@ type Props = {
 
 export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
   const snap = useAircraft(initial, mockOn);
-  const { pos, unavailable } = useRiderPos();
+  const { pos } = useRiderPos();
   const [activity, setActivity] = useState<ActivityEntry[]>(initialActivity);
 
   const smoky = snap.aircraft.find((a) => a.tail === SMOKY_TAIL);
@@ -35,15 +33,6 @@ export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
     () => snap.aircraft.filter((a) => a.airborne),
     [snap.aircraft],
   );
-
-  // Speed in mph from device. Some browsers report null when stationary.
-  const mph =
-    pos?.speedMps != null && pos.speedMps >= 0
-      ? pos.speedMps * MPS_TO_MPH
-      : 0;
-  const hasSpeedSignal = pos?.speedMps != null && pos.speedMps >= 0;
-  const limit = DEFAULT_SPEED_LIMIT_MPH;
-  const speeding = mph > limit;
 
   // Nearest airborne plane by Haversine.
   const nearest = useMemo<{
@@ -114,40 +103,9 @@ export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
         />
       </header>
 
-      <Card>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            paddingTop: 6,
-          }}
-        >
-          <Speedometer
-            mph={mph}
-            limit={limit}
-            hasSignal={hasSpeedSignal}
-          />
-        </div>
-        {unavailable && (
-          <div
-            className="ss-mono"
-            style={{
-              marginTop: 8,
-              textAlign: "center",
-              fontSize: 11,
-              color: SS_TOKENS.fg2,
-              letterSpacing: ".04em",
-            }}
-          >
-            Location off · speed unavailable
-          </div>
-        )}
-      </Card>
-
       <NearestCard nearest={nearest} riderHasFix={Boolean(pos)} smokyUp={up} />
 
       <ContextLine
-        speeding={speeding}
         airborneCount={airborne.length}
         nearest={nearest}
       />
@@ -232,23 +190,17 @@ function NearestCard({
 }
 
 function ContextLine({
-  speeding,
   airborneCount,
   nearest,
 }: {
-  speeding: boolean;
   airborneCount: number;
   nearest: { plane: Aircraft; distanceNm: number } | null;
 }) {
   let text: string;
   let color: string;
-  if (
-    speeding &&
-    nearest &&
-    nearest.distanceNm <= NEAR_NM
-  ) {
+  if (nearest && nearest.distanceNm <= NEAR_NM) {
     const display = nearest.plane.nickname || nearest.plane.tail;
-    text = `Mind the throttle · ${display} ${nearest.distanceNm.toFixed(1)}nm away`;
+    text = `Heads up · ${display} ${nearest.distanceNm.toFixed(1)}nm away`;
     color = SS_TOKENS.warn;
   } else if (airborneCount > 0) {
     text = "Smokey up but not nearby";

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from "react";
 const TABS: { id: string; label: string; href: string; icon: ReactNode }[] = [
   { id: "home", label: "Home", href: "/", icon: <HomeIcon /> },
   { id: "radar", label: "Radar", href: "/radar", icon: <RadarIcon /> },
+  { id: "dash", label: "Dash", href: "/dash", icon: <DashIcon /> },
   { id: "activity", label: "Activity", href: "/activity", icon: <ActivityIcon /> },
   { id: "about", label: "About", href: "/about", icon: <InfoIcon /> },
 ];
@@ -137,6 +138,25 @@ function InfoIcon() {
       <circle cx="12" cy="12" r="10" />
       <path d="M12 16v-4" />
       <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+// Lucide-style "gauge" icon — at-a-glance dashboard summary.
+function DashIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m12 14 4-4" />
+      <path d="M3.34 19a10 10 0 1 1 17.32 0" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- /dash route was reachable by URL but missing from the tab bar — added it between Radar and Activity with a gauge icon.
- Stripped the Speedometer card from DashShell per the no-speed-collection stance.
- Simplified the context line to a proximity message ("Heads up · <plane> X.Xnm away") with the speed-throttle branch removed.

## Test plan
- [ ] /radar / / / about — TabBar shows 5 entries with /dash present.
- [ ] Tap Dash → reaches /dash; no speedometer rendered.
- [ ] Within 5 nm of Smokey: context line shows "Heads up · …".
- [ ] No 5nm proximity but airborne: context line shows "Smokey up but not nearby".

🤖 Generated with [Claude Code](https://claude.com/claude-code)