### PR TITLE
feat(dash): ambient amber flash on smokey/patrol within 5nm

### DIFF
--- a/components/DashShell.tsx
+++ b/components/DashShell.tsx
@@ -10,6 +10,7 @@ import { haversineNm } from "@/lib/geo";
 import { StatusPill } from "./StatusPill";
 import { Card } from "./Card";
 import { AlertsOptInCard } from "./AlertsOptInCard";
+import { ProximityFlash } from "./ProximityFlash";
 import type { Aircraft, Snapshot } from "@/lib/types";
 import type { ActivityEntry } from "@/lib/activity";
 
@@ -113,6 +114,14 @@ export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
       <ActivityFeed entries={activity} />
 
       <AlertsOptInCard />
+
+      <ProximityFlash
+        active={
+          nearest != null &&
+          nearest.distanceNm <= NEAR_NM &&
+          (nearest.plane.role === "smokey" || nearest.plane.role === "patrol")
+        }
+      />
     </main>
   );
 }

--- a/components/ProximityFlash.tsx
+++ b/components/ProximityFlash.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// Ambient amber flash overlay rendered on /dash when a smokey or patrol
+// aircraft is within PROXIMITY_NM nautical miles of the rider. Pulses
+// gently via CSS keyframes so it's noticeable in peripheral vision
+// without strobing — sits as a fixed-position overlay above the page
+// content but below the tab bar (z-index: 49 vs TabBar's 50).
+//
+// Renders nothing when inactive so React can skip it cleanly.
+
+import { SS_TOKENS } from "@/lib/tokens";
+
+const KEYFRAME_ID = "ss-proximity-flash-keyframes";
+// One-time global keyframe injection — guarded so multiple mounts of
+// ProximityFlash (e.g. fast nav back to /dash) don't pile up <style>
+// tags. The rule itself is idempotent.
+function ensureKeyframes() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(KEYFRAME_ID)) return;
+  const style = document.createElement("style");
+  style.id = KEYFRAME_ID;
+  style.textContent = `@keyframes ss-proximity-flash {
+    0%, 100% { opacity: 0.10; }
+    50% { opacity: 0.28; }
+  }`;
+  document.head.appendChild(style);
+}
+
+export function ProximityFlash({ active }: { active: boolean }) {
+  if (!active) return null;
+  ensureKeyframes();
+  return (
+    <div
+      aria-hidden
+      data-testid="proximity-flash"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        background: `radial-gradient(circle at 50% 50%, transparent 30%, ${SS_TOKENS.alert} 130%)`,
+        animation: "ss-proximity-flash 1.8s ease-in-out infinite",
+        zIndex: 49,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- New ProximityFlash component renders a fixed-position radial amber overlay that pulses 10-28% opacity over a 1.8s cycle whenever a smokey- or patrol-role bird is within 5 nm.
- Wired into DashShell so /dash gets the ambient cue without polluting other routes.
- Transport-role planes deliberately do not trigger — they don't change rider behavior.

## Test plan
- [ ] /dash with a mock smokey/patrol within 5 nm → screen pulses amber softly.
- [ ] /dash with airborne but >5 nm → no flash.
- [ ] /dash with a transport-role plane within 5 nm → no flash.
- [ ] Tab away and back — flash resumes without piling up extra `<style>` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)