### PR TITLE
feat(radar): unify operator/tail filter — markers + heat

### DIFF
--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -14,63 +14,25 @@ import type { Map as MaplibreMap, GeoJSONSource } from "maplibre-gl";
 import { SS_TOKENS } from "@/lib/tokens";
 import type { HotZone } from "@/lib/hotzones";
 import type { LearningState } from "@/lib/learning";
+import {
+  DEFAULT_RADAR_FILTER,
+  OPERATORS,
+  RADAR_FILTER_CHANGE_EVENT,
+  SMOKY_TAILS,
+  readRadarFilter,
+  writeRadarFilter,
+  type RadarFilter as Filter,
+} from "@/lib/radar-filter";
 import { Tooltip } from "./Tooltip";
 import { LearningPanel } from "./LearningPanel";
 
 const VISIBLE_KEY = "ss_hotzones_visible";
-const FILTER_KEY = "ss_hotzones_filter";
 const SOURCE_ID = "hotzones";
 const LAYER_ID = "hotzones-heat";
 const AIRCRAFT_LAYER_ID = "aircraft";
 const TABBAR_HEIGHT = 66;
 
-const SMOKY_TAILS = ["N305DK", "N2446X"] as const;
-const OPERATORS = [
-  "WSP",
-  "KCSO",
-  "Pierce SO",
-  "Snohomish SO",
-  "Spokane SO",
-  "State of WA",
-] as const;
-
-type ShowMode = "all" | "smoky" | "operator";
-type Region = "puget_sound" | "all";
-
-type Filter = {
-  showMode: ShowMode;
-  operator: string | null;
-  region: Region;
-};
-
-const DEFAULT_FILTER: Filter = {
-  showMode: "all",
-  operator: "WSP",
-  region: "puget_sound",
-};
-
-function readFilter(): Filter {
-  if (typeof window === "undefined") return DEFAULT_FILTER;
-  try {
-    const raw = window.localStorage.getItem(FILTER_KEY);
-    if (!raw) return DEFAULT_FILTER;
-    const parsed = JSON.parse(raw) as Partial<Filter>;
-    return {
-      showMode:
-        parsed.showMode === "smoky" || parsed.showMode === "operator"
-          ? parsed.showMode
-          : "all",
-      operator:
-        typeof parsed.operator === "string" &&
-        OPERATORS.includes(parsed.operator as (typeof OPERATORS)[number])
-          ? parsed.operator
-          : "WSP",
-      region: parsed.region === "all" ? "all" : "puget_sound",
-    };
-  } catch {
-    return DEFAULT_FILTER;
-  }
-}
+const DEFAULT_FILTER = DEFAULT_RADAR_FILTER;
 
 function buildQueryString(f: Filter): string {
   const p = new URLSearchParams();
@@ -99,13 +61,23 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
 
   console.log("[HZ] mount/render — map?", !!map, "zones?", zones?.length ?? null);
 
-  // Load persisted state once on mount.
+  // Load persisted state once on mount, and stay in sync with any other
+  // component that mutates the shared radar filter (e.g. a future global
+  // FilterPanel) via the cross-component change event.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const v = window.localStorage.getItem(VISIBLE_KEY);
     if (v === "0") setEnabled(false);
     else if (v === "1") setEnabled(true);
-    setFilter(readFilter());
+    setFilter(readRadarFilter());
+    const onFilterChange = (e: Event) => {
+      const detail = (e as CustomEvent<Filter>).detail;
+      if (detail) setFilter(detail);
+    };
+    window.addEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+    return () => {
+      window.removeEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+    };
   }, []);
 
   useEffect(() => {
@@ -113,9 +85,10 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
     window.localStorage.setItem(VISIBLE_KEY, enabled ? "1" : "0");
   }, [enabled]);
 
+  // Persist via the shared writer so the change event fires for any
+  // other subscriber (RadarShell, etc) listening for filter updates.
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(FILTER_KEY, JSON.stringify(filter));
+    writeRadarFilter(filter);
   }, [filter]);
 
   // Fetch (re-fetch when filter changes). Each request is small + edge-cached

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -16,6 +16,13 @@ import { FreshnessLabel } from "./FreshnessLabel";
 import { RegionSelector } from "./RegionSelector";
 import { REGION_CHANGE_EVENT, getRegion } from "@/lib/region-pref";
 import type { RegionId } from "@/lib/regions";
+import {
+  DEFAULT_RADAR_FILTER,
+  RADAR_FILTER_CHANGE_EVENT,
+  passesAircraftFilter,
+  readRadarFilter,
+  type RadarFilter,
+} from "@/lib/radar-filter";
 import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
 import type { LearningState } from "@/lib/learning";
 
@@ -56,7 +63,31 @@ export function RadarShell({
     [snap.aircraft],
   );
   const status = useMemo(() => computeStatus(snap, fleetMap), [snap, fleetMap]);
-  const airborne = snap.aircraft.filter((a) => a.airborne);
+  // Mirror the heatmap chevron's filter so aircraft markers stay in sync —
+  // tapping "Smokey only" should hide non-smokey markers as well as
+  // non-smokey heat. Read once on mount and subscribe to the shared
+  // change event for cross-component updates.
+  const [radarFilter, setRadarFilter] = useState<RadarFilter>(
+    DEFAULT_RADAR_FILTER,
+  );
+  useEffect(() => {
+    setRadarFilter(readRadarFilter());
+    const onFilterChange = (e: Event) => {
+      const detail = (e as CustomEvent<RadarFilter>).detail;
+      if (detail) setRadarFilter(detail);
+    };
+    window.addEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+    return () => {
+      window.removeEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+    };
+  }, []);
+  const airborne = useMemo(
+    () =>
+      snap.aircraft.filter(
+        (a) => a.airborne && passesAircraftFilter(a, radarFilter),
+      ),
+    [snap.aircraft, radarFilter],
+  );
   const total = snap.aircraft.length;
   const pillKind = status.kind;
   const pillTooltip =

--- a/lib/radar-filter.ts
+++ b/lib/radar-filter.ts
@@ -1,0 +1,89 @@
+// Shared radar filter state — operator / tail-set / region. Lives in
+// localStorage under "ss_hotzones_filter" (legacy key kept so existing
+// user state survives this refactor) and broadcasts changes via a
+// CustomEvent so the heatmap chevron panel and the aircraft marker
+// layer stay in sync without a context provider.
+//
+// Region filtering is applied server-side only (lib/hotzones.ts) — the
+// passesAircraftFilter predicate intentionally ignores it because the
+// rider's airborne marker view should not hide planes based on the
+// fleet-aggregation envelope.
+
+export type RadarFilterShowMode = "all" | "smoky" | "operator";
+export type RadarFilterRegion = "puget_sound" | "all";
+
+export type RadarFilter = {
+  showMode: RadarFilterShowMode;
+  operator: string | null;
+  region: RadarFilterRegion;
+};
+
+export const RADAR_FILTER_KEY = "ss_hotzones_filter";
+export const RADAR_FILTER_CHANGE_EVENT = "ss-radar-filter-change";
+
+export const SMOKY_TAILS = ["N305DK", "N2446X"] as const;
+export const OPERATORS = [
+  "WSP",
+  "KCSO",
+  "Pierce SO",
+  "Snohomish SO",
+  "Spokane SO",
+  "State of WA",
+] as const;
+
+export const DEFAULT_RADAR_FILTER: RadarFilter = {
+  showMode: "all",
+  operator: "WSP",
+  region: "puget_sound",
+};
+
+export function readRadarFilter(): RadarFilter {
+  if (typeof window === "undefined") return DEFAULT_RADAR_FILTER;
+  try {
+    const raw = window.localStorage.getItem(RADAR_FILTER_KEY);
+    if (!raw) return DEFAULT_RADAR_FILTER;
+    const parsed = JSON.parse(raw) as Partial<RadarFilter>;
+    return {
+      showMode:
+        parsed.showMode === "smoky" || parsed.showMode === "operator"
+          ? parsed.showMode
+          : "all",
+      operator:
+        typeof parsed.operator === "string" &&
+        OPERATORS.includes(parsed.operator as (typeof OPERATORS)[number])
+          ? parsed.operator
+          : "WSP",
+      region: parsed.region === "all" ? "all" : "puget_sound",
+    };
+  } catch {
+    return DEFAULT_RADAR_FILTER;
+  }
+}
+
+export function writeRadarFilter(f: RadarFilter): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RADAR_FILTER_KEY, JSON.stringify(f));
+    window.dispatchEvent(
+      new CustomEvent(RADAR_FILTER_CHANGE_EVENT, { detail: f }),
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+export function passesAircraftFilter(
+  aircraft: { tail: string; operator: string },
+  f: RadarFilter,
+): boolean {
+  if (f.showMode === "all") return true;
+  if (f.showMode === "smoky") {
+    return SMOKY_TAILS.includes(
+      aircraft.tail as (typeof SMOKY_TAILS)[number],
+    );
+  }
+  if (f.showMode === "operator" && f.operator) {
+    return aircraft.operator === f.operator;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Extracted Filter type + helpers from HotZoneLayer into lib/radar-filter.ts.
- New passesAircraftFilter() predicate; RadarShell now applies it before passing markers to RadarMap.
- Cross-component sync via "ss-radar-filter-change" CustomEvent — chevron + marker layer update together.
- Region filter stays server-side (heat aggregation only); marker visibility is rider-local.

## Test plan
- [ ] /radar default — all airborne markers + full heatmap (unchanged).
- [ ] Open chevron, pick "Smokey only" → only Smokey markers + Smokey heat zones.
- [ ] Pick operator WSP → only WSP markers + WSP heat zones.
- [ ] Pick operator KCSO → only KCSO markers + KCSO heat zones.
- [ ] Reload — selection persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)