### PR TITLE
feat(zones): rider-defined geofences — add at rider, tap to remove

### DIFF
--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -10,6 +10,8 @@ import { computeStatus } from "@/lib/status";
 import { StatusPill } from "./StatusPill";
 import { SpottedButton } from "./SpottedButton";
 import { HotZoneLayer } from "./HotZoneLayer";
+import { UserZoneLayer } from "./UserZoneLayer";
+import { addUserZone } from "@/lib/user-zones";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import { FreshnessLabel } from "./FreshnessLabel";
@@ -163,6 +165,11 @@ export function RadarShell({
         bottomBoost={airborne.length > 0 ? 130 : 0}
         learning={learning}
       />
+      <UserZoneLayer map={map} />
+      <AddZoneButton
+        rider={rider}
+        onAdded={(label) => flashToast(setToast, `Zone "${label}" added`)}
+      />
       <DistanceRingsToggle
         active={showRings}
         onToggle={() => setShowRings((v) => !v)}
@@ -259,6 +266,66 @@ function flashToast(
 ) {
   setter(message);
   setTimeout(() => setter(null), durationMs);
+}
+
+// "+" floating button — drops a 5nm geofence at the rider's current
+// position. Disabled until geolocation resolves so we never save a
+// zone at the default Puget Sound centroid by accident. Long-tap is
+// intentionally not used here since the radar map below already swallows
+// long-press gestures for chevron interactions.
+function AddZoneButton({
+  rider,
+  onAdded,
+}: {
+  rider: RiderPos | null;
+  onAdded: (label: string) => void;
+}) {
+  const disabled = !rider;
+  return (
+    <Tooltip side="right" content="Add a 5nm zone at your location">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (!rider) return;
+          const label =
+            window.prompt(
+              "Zone label (e.g. Home, Meeting point):",
+              "Zone",
+            )?.trim() || "Zone";
+          const z = addUserZone({
+            lat: rider.lat,
+            lon: rider.lon,
+            radiusNm: 5,
+            label,
+          });
+          onAdded(z.label);
+        }}
+        aria-label="Add geofence at your location"
+        style={{
+          position: "absolute",
+          top: 60,
+          left: 64,
+          width: 28,
+          height: 28,
+          borderRadius: "50%",
+          border: `.5px solid ${SS_TOKENS.hairline2}`,
+          background: "rgba(11,13,16,.7)",
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
+          color: disabled ? SS_TOKENS.fg2 : SS_TOKENS.fg0,
+          fontSize: 16,
+          fontWeight: 700,
+          lineHeight: 1,
+          opacity: disabled ? 0.5 : 1,
+          cursor: disabled ? "not-allowed" : "pointer",
+          zIndex: 10,
+        }}
+      >
+        +
+      </button>
+    </Tooltip>
+  );
 }
 
 function Toast({

--- a/components/UserZoneLayer.tsx
+++ b/components/UserZoneLayer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+// Renders rider-defined geofence circles on the radar map and handles
+// tap-to-remove (with a confirm dialog so edge taps aren't destructive).
+
+import { useEffect, useRef } from "react";
+import type {
+  Map as MaplibreMap,
+  GeoJSONSource,
+  MapMouseEvent,
+  MapGeoJSONFeature,
+} from "maplibre-gl";
+import { SS_TOKENS } from "@/lib/tokens";
+import {
+  readUserZones,
+  removeUserZone,
+  USER_ZONES_CHANGE_EVENT,
+  type UserZone,
+} from "@/lib/user-zones";
+
+const SOURCE_ID = "user-zones";
+const FILL_LAYER_ID = "user-zones-fill";
+const LINE_LAYER_ID = "user-zones-line";
+const NM_PER_DEG_LAT = 1 / 60;
+const RING_SEGMENTS = 64;
+
+function circleRing(lat: number, lon: number, radiusNm: number): Array<[number, number]> {
+  const dLat = radiusNm * NM_PER_DEG_LAT;
+  const dLon = dLat / Math.max(0.01, Math.cos((lat * Math.PI) / 180));
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i <= RING_SEGMENTS; i++) {
+    const theta = (i / RING_SEGMENTS) * 2 * Math.PI;
+    out.push([lon + dLon * Math.sin(theta), lat + dLat * Math.cos(theta)]);
+  }
+  return out;
+}
+
+function toGeoJSON(zones: UserZone[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: zones.map((z) => ({
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [circleRing(z.lat, z.lon, z.radiusNm)],
+      },
+      properties: { id: z.id, label: z.label },
+    })),
+  };
+}
+
+export function UserZoneLayer({ map }: { map: MaplibreMap | null }) {
+  const zonesRef = useRef<UserZone[]>([]);
+
+  useEffect(() => {
+    if (!map) return;
+    zonesRef.current = readUserZones();
+
+    const ensureLayer = () => {
+      if (!map.isStyleLoaded() || map.getSource(SOURCE_ID)) return;
+      const beforeId = map.getLayer("aircraft") ? "aircraft" : undefined;
+      map.addSource(SOURCE_ID, { type: "geojson", data: toGeoJSON(zonesRef.current) });
+      map.addLayer({
+        id: FILL_LAYER_ID,
+        type: "fill",
+        source: SOURCE_ID,
+        paint: { "fill-color": SS_TOKENS.sky, "fill-opacity": 0.1 },
+      }, beforeId);
+      map.addLayer({
+        id: LINE_LAYER_ID,
+        type: "line",
+        source: SOURCE_ID,
+        paint: {
+          "line-color": SS_TOKENS.sky,
+          "line-opacity": 0.55,
+          "line-width": 1,
+          "line-dasharray": [2, 2],
+        },
+      }, beforeId);
+    };
+
+    if (map.isStyleLoaded()) ensureLayer();
+    map.on("load", ensureLayer);
+    map.on("styledata", ensureLayer);
+
+    const onZonesChange = (e: Event) => {
+      const detail = (e as CustomEvent<UserZone[]>).detail;
+      zonesRef.current = detail ?? readUserZones();
+      const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+      if (src) src.setData(toGeoJSON(zonesRef.current));
+    };
+    window.addEventListener(USER_ZONES_CHANGE_EVENT, onZonesChange);
+
+    const onZoneClick = (e: MapMouseEvent & { features?: MapGeoJSONFeature[] }) => {
+      // Don't intercept if the same click hit an aircraft chevron — that
+      // gesture belongs to follow mode in RadarMap.
+      if (map.queryRenderedFeatures(e.point, { layers: ["aircraft"] }).length > 0) return;
+      const feat = e.features?.[0];
+      const id = feat?.properties?.id;
+      const label = feat?.properties?.label ?? "this zone";
+      if (typeof id !== "string") return;
+      if (window.confirm(`Remove zone "${label}"?`)) removeUserZone(id);
+    };
+    map.on("click", FILL_LAYER_ID, onZoneClick);
+
+    return () => {
+      window.removeEventListener(USER_ZONES_CHANGE_EVENT, onZonesChange);
+      map.off("load", ensureLayer);
+      map.off("styledata", ensureLayer);
+      map.off("click", FILL_LAYER_ID, onZoneClick);
+      try {
+        if (map.getLayer(LINE_LAYER_ID)) map.removeLayer(LINE_LAYER_ID);
+        if (map.getLayer(FILL_LAYER_ID)) map.removeLayer(FILL_LAYER_ID);
+        if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+      } catch {
+        // map may be torn down already
+      }
+    };
+  }, [map]);
+
+  return null;
+}

--- a/lib/user-zones.ts
+++ b/lib/user-zones.ts
@@ -1,0 +1,76 @@
+// Rider-defined geofences. localStorage only (no accounts), with a
+// CustomEvent so subscribers stay in sync.
+
+export type UserZone = {
+  id: string;
+  lat: number;
+  lon: number;
+  radiusNm: number;
+  label: string;
+  createdAt: number;
+};
+
+const KEY = "ss_user_zones";
+export const USER_ZONES_CHANGE_EVENT = "ss-user-zones-change";
+
+function isUserZone(v: unknown): v is UserZone {
+  const z = v as Record<string, unknown> | null;
+  return (
+    !!z &&
+    typeof z.id === "string" &&
+    typeof z.lat === "number" &&
+    typeof z.lon === "number" &&
+    typeof z.radiusNm === "number" &&
+    typeof z.label === "string" &&
+    typeof z.createdAt === "number"
+  );
+}
+
+export function readUserZones(): UserZone[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isUserZone) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(zones: UserZone[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(zones));
+    window.dispatchEvent(
+      new CustomEvent<UserZone[]>(USER_ZONES_CHANGE_EVENT, { detail: zones }),
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+export function addUserZone(input: {
+  lat: number;
+  lon: number;
+  radiusNm: number;
+  label: string;
+}): UserZone {
+  const zone: UserZone = {
+    id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`,
+    ...input,
+    createdAt: Date.now(),
+  };
+  const all = readUserZones();
+  all.push(zone);
+  writeAll(all);
+  return zone;
+}
+
+export function removeUserZone(id: string): void {
+  writeAll(readUserZones().filter((z) => z.id !== id));
+}
+
+export function clearUserZones(): void {
+  writeAll([]);
+}


### PR DESCRIPTION
## Summary
- New "+" button on /radar drops a 5nm geofence at the rider's current position.
- Zones render as dashed sky-tinted circles under the aircraft layer.
- Tap inside a zone (with no aircraft at that point) → confirm dialog → remove.
- localStorage-only (ss_user_zones); CustomEvent fan-out keeps the layer in sync.

## Note
- 265-line PR — over the standard 200-line gate. Split rationale: the lib (76 lines) + render layer (122 lines) + RadarShell wiring (67 lines) form one feature; splitting them produces a no-op middle PR. Push integration deliberately deferred — that needs server-side state and lands separately.

## Test plan
- [ ] Granted location → "+" enabled, click prompts for label, drops a 5nm circle at rider.
- [ ] No location → "+" disabled at 50% opacity.
- [ ] Tap inside a zone (empty area) → confirm prompt → zone disappears.
- [ ] Tap aircraft inside a zone → follow-mode triggers; no zone-removal prompt.
- [ ] Reload — zones persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)