### PR TITLE
feat(home): visible Arm-alerts CTA with 14-day dismiss memory

### DIFF
--- a/components/ArmAlertsCallout.tsx
+++ b/components/ArmAlertsCallout.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+// Visible "Arm alerts" call-to-action for the home page. Self-hides when
+// it isn't relevant: armed already, browser blocked, push unsupported,
+// or the rider dismissed it within the last 14 days. The settings page
+// is one tap away — the CTA exists purely to point riders at it.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { SS_TOKENS } from "@/lib/tokens";
+import { isPushSupported, getPushPermission } from "@/lib/push/client";
+
+const DISMISS_KEY = "ss_arm_alerts_dismissed_at";
+const DISMISS_DAYS = 14;
+const DISMISS_MS = DISMISS_DAYS * 24 * 60 * 60 * 1000;
+
+type State =
+  | { kind: "loading" }
+  | { kind: "unsupported" }
+  | { kind: "denied" }
+  | { kind: "armed" }
+  | { kind: "available"; recentlyDismissed: boolean };
+
+export function ArmAlertsCallout() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    if (!isPushSupported()) {
+      setState({ kind: "unsupported" });
+      return;
+    }
+    if (getPushPermission() === "denied") {
+      setState({ kind: "denied" });
+      return;
+    }
+    let cancelled = false;
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => {
+        if (cancelled) return;
+        if (sub) {
+          setState({ kind: "armed" });
+          return;
+        }
+        const dismissedAt = Number(
+          window.localStorage.getItem(DISMISS_KEY) ?? "0",
+        );
+        const recentlyDismissed = Date.now() - dismissedAt < DISMISS_MS;
+        setState({ kind: "available", recentlyDismissed });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ kind: "available", recentlyDismissed: false });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "loading" || state.kind === "unsupported") return null;
+  // Armed state has its own indicator (AlertsStateChip); don't double up.
+  if (state.kind === "armed") return null;
+
+  if (state.kind === "denied") {
+    return (
+      <div
+        className="ss-mono"
+        style={{
+          fontSize: 11,
+          color: SS_TOKENS.fg2,
+          padding: "8px 12px",
+          border: `.5px solid ${SS_TOKENS.hairline}`,
+          borderRadius: 8,
+          letterSpacing: ".04em",
+        }}
+      >
+        Browser blocked alerts. Open Safari → Settings → SmokySignal to unblock.
+      </div>
+    );
+  }
+
+  if (state.recentlyDismissed) return null;
+
+  return (
+    <div
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.alert}`,
+        borderRadius: 12,
+        padding: 14,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div className="ss-eyebrow" style={{ marginBottom: 4 }}>
+          OPT IN
+        </div>
+        <div
+          style={{
+            fontSize: 14,
+            fontWeight: 700,
+            color: SS_TOKENS.fg0,
+            lineHeight: 1.3,
+          }}
+        >
+          Get a ping when Smokey&rsquo;s up.
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+        <Link
+          href="/settings/alerts"
+          style={{
+            background: SS_TOKENS.alert,
+            color: SS_TOKENS.bg0,
+            padding: "8px 14px",
+            borderRadius: 8,
+            fontSize: 13,
+            fontWeight: 600,
+            textDecoration: "none",
+            whiteSpace: "nowrap",
+          }}
+        >
+          Arm alerts
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            window.localStorage.setItem(DISMISS_KEY, String(Date.now()));
+            setState({ kind: "available", recentlyDismissed: true });
+          }}
+          aria-label="Dismiss for 14 days"
+          style={{
+            background: "none",
+            border: "none",
+            color: SS_TOKENS.fg2,
+            fontSize: 12,
+            cursor: "pointer",
+            padding: "8px 6px",
+          }}
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -17,6 +17,7 @@ import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import { Logo } from "./brand/Logo";
 import { FreshnessLabel } from "./FreshnessLabel";
+import { ArmAlertsCallout } from "./ArmAlertsCallout";
 
 // Hide the activity strip when the most recent event is older than this —
 // a stale "Guardian One up · 8 hours ago" looks more like a bug than a
@@ -200,6 +201,8 @@ export function Glanceable({
       )}
 
       {latestActivity && <ActivityStrip latest={latestActivity} />}
+
+      <ArmAlertsCallout />
 
       {others.length > 0 && <Others others={others} />}
 


### PR DESCRIPTION
## Summary
- New ArmAlertsCallout under the home activity strip — amber-bordered card with "Arm alerts" → /settings/alerts and a "Not now" dismiss.
- Dismiss writes ss_arm_alerts_dismissed_at; card hides for 14 days.
- Self-hides on unsupported, denied (with unblock copy), and armed states.

## Test plan
- [ ] Fresh browser (no subscription) → CTA renders under activity strip.
- [ ] Click "Arm alerts" → lands on /settings/alerts.
- [ ] Click "Not now" → CTA disappears; reload → stays hidden for 14 days.
- [ ] Already-armed (subscribed) browser → CTA hidden.
- [ ] Notification.permission denied → tiny note explaining how to unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)