### PR TITLE
feat(home): ALERTS ON/OFF mono chip linking to settings

### DIFF
--- a/components/AlertsStateChip.tsx
+++ b/components/AlertsStateChip.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Tiny mono indicator showing the rider's current push-alerts state.
+// Renders only when there's something useful to say — silent on
+// unsupported browsers and during the brief load window — and links
+// to /settings/alerts so the chip is also the entry point if the
+// rider wants to change state.
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { SS_TOKENS } from "@/lib/tokens";
+import { isPushSupported } from "@/lib/push/client";
+
+type State = "loading" | "unsupported" | "denied" | "available" | "armed";
+
+export function AlertsStateChip() {
+  const [state, setState] = useState<State>("loading");
+
+  useEffect(() => {
+    if (!isPushSupported()) {
+      setState("unsupported");
+      return;
+    }
+    if (Notification.permission === "denied") {
+      setState("denied");
+      return;
+    }
+    let cancelled = false;
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => {
+        if (!cancelled) setState(sub ? "armed" : "available");
+      })
+      .catch(() => {
+        if (!cancelled) setState("available");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === "loading" || state === "unsupported") return null;
+
+  const armed = state === "armed";
+  const denied = state === "denied";
+  const color = armed ? SS_TOKENS.clear : denied ? SS_TOKENS.warn : SS_TOKENS.fg2;
+  const label = armed ? "ALERTS ON" : denied ? "ALERTS BLOCKED" : "ALERTS OFF";
+
+  return (
+    <Link
+      href="/settings/alerts"
+      className="ss-mono"
+      aria-label={`Push alerts: ${label.toLowerCase()}. Tap to manage.`}
+      style={{
+        fontSize: 9.5,
+        letterSpacing: ".08em",
+        color,
+        textDecoration: "none",
+        padding: "2px 6px",
+        border: `.5px solid ${SS_TOKENS.hairline2}`,
+        borderRadius: 4,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -18,6 +18,7 @@ import { Tooltip } from "./Tooltip";
 import { Logo } from "./brand/Logo";
 import { FreshnessLabel } from "./FreshnessLabel";
 import { ArmAlertsCallout } from "./ArmAlertsCallout";
+import { AlertsStateChip } from "./AlertsStateChip";
 
 // Hide the activity strip when the most recent event is older than this —
 // a stale "Guardian One up · 8 hours ago" looks more like a bug than a
@@ -149,6 +150,7 @@ export function Glanceable({
           >
             LIVE
           </span>
+          <AlertsStateChip />
         </div>
         <Tooltip
           side="bottom"


### PR DESCRIPTION
## Summary
- New AlertsStateChip in the home header (next to LIVE) showing push-alerts state at a glance.
- Three labels: ALERTS ON (clear), ALERTS OFF (muted), ALERTS BLOCKED (warn).
- Each label links to /settings/alerts so the chip doubles as the manage entry point.
- Renders nothing on unsupported browsers and during the brief SW-ready load.

## Test plan
- [ ] Fresh browser → ALERTS OFF chip rendered.
- [ ] After arming → reload home → ALERTS ON in green.
- [ ] Notification.permission === denied → ALERTS BLOCKED in amber.
- [ ] Tap chip → lands on /settings/alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)