### PR TITLE
feat(hotzones): per-region heat filter — bbox per RegionId

### DIFF
--- a/app/api/hotzones/route.ts
+++ b/app/api/hotzones/route.ts
@@ -5,21 +5,29 @@ import {
   type HotZone,
 } from "@/lib/hotzones";
 import { getRegistry } from "@/lib/registry";
+import { REGIONS, type RegionBbox, type RegionId } from "@/lib/regions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Rider-facing default region — Puget Sound bbox. Wider than the
-// hot-zone aggregate's defensive Pacific-NW envelope so we still see
-// Eastern WA enforcement when the user opts into the statewide view.
-const PUGET_SOUND = {
-  latMin: 46.5,
-  latMax: 48.5,
-  lonMin: -123.5,
-  lonMax: -121.5,
-} as const;
+// Resolve the rider-facing region selector → bbox. Accepts either the
+// new `region_id` query param (any RegionId from lib/regions.ts) or the
+// legacy `region` value ("puget_sound" | "all") for backward compat
+// with the chevron filter UI.
+function resolveBbox(url: URL): { regionId: RegionId; bbox: RegionBbox } {
+  const idParam = url.searchParams.get("region_id");
+  if (idParam && idParam in REGIONS) {
+    const id = idParam as RegionId;
+    return { regionId: id, bbox: REGIONS[id].bbox };
+  }
+  const legacy = url.searchParams.get("region");
+  if (legacy === "all") {
+    return { regionId: "all_wa", bbox: REGIONS.all_wa.bbox };
+  }
+  return { regionId: "puget_sound", bbox: REGIONS.puget_sound.bbox };
+}
 
-function inBbox(z: HotZone, b: typeof PUGET_SOUND): boolean {
+function inBbox(z: HotZone, b: NonNullable<RegionBbox>): boolean {
   return (
     z.lat >= b.latMin &&
     z.lat <= b.latMax &&
@@ -38,7 +46,7 @@ function parseList(raw: string | null): string[] {
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const region = url.searchParams.get("region") === "all" ? "all" : "puget_sound";
+  const { regionId, bbox } = resolveBbox(url);
   const tails = parseList(url.searchParams.get("tails"));
   const operator = url.searchParams.get("operator")?.trim() ?? null;
 
@@ -60,7 +68,7 @@ export async function GET(req: Request) {
   }
 
   const zones = allZones.filter((z) => {
-    if (region === "puget_sound" && !inBbox(z, PUGET_SOUND)) return false;
+    if (bbox && !inBbox(z, bbox)) return false;
     if (allowedTails && !z.tails.some((t) => allowedTails!.has(t))) return false;
     return true;
   });
@@ -69,7 +77,7 @@ export async function GET(req: Request) {
     {
       zones,
       last_refresh_ts: lastRefresh,
-      region,
+      region_id: regionId,
       filter_tails: tails,
       filter_operator: operator,
       total_unfiltered: allZones.length,

--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -23,6 +23,8 @@ import {
   writeRadarFilter,
   type RadarFilter as Filter,
 } from "@/lib/radar-filter";
+import { REGION_CHANGE_EVENT, getRegion } from "@/lib/region-pref";
+import type { RegionId } from "@/lib/regions";
 import { Tooltip } from "./Tooltip";
 import { LearningPanel } from "./LearningPanel";
 
@@ -34,8 +36,13 @@ const TABBAR_HEIGHT = 66;
 
 const DEFAULT_FILTER = DEFAULT_RADAR_FILTER;
 
-function buildQueryString(f: Filter): string {
+function buildQueryString(f: Filter, regionId: RegionId): string {
   const p = new URLSearchParams();
+  // region_id (rider's selector pref) takes precedence over the legacy
+  // chevron region toggle. The chevron toggle still informs the API via
+  // the `region` param for back-compat, but region_id wins server-side
+  // when both are present.
+  p.set("region_id", regionId);
   p.set("region", f.region);
   if (f.showMode === "smoky") p.set("tails", SMOKY_TAILS.join(","));
   if (f.showMode === "operator" && f.operator) p.set("operator", f.operator);
@@ -52,6 +59,7 @@ type Props = {
 export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
   const [enabled, setEnabled] = useState<boolean>(true);
   const [filter, setFilter] = useState<Filter>(DEFAULT_FILTER);
+  const [regionId, setRegionId] = useState<RegionId>("puget_sound");
   const [zones, setZones] = useState<HotZone[] | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
   // Stable refs so the addLayerOnce closure (captured at attach time)
@@ -70,13 +78,20 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
     if (v === "0") setEnabled(false);
     else if (v === "1") setEnabled(true);
     setFilter(readRadarFilter());
+    setRegionId(getRegion());
     const onFilterChange = (e: Event) => {
       const detail = (e as CustomEvent<Filter>).detail;
       if (detail) setFilter(detail);
     };
+    const onRegionChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ id: RegionId }>).detail;
+      setRegionId(detail?.id ?? getRegion());
+    };
     window.addEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+    window.addEventListener(REGION_CHANGE_EVENT, onRegionChange);
     return () => {
       window.removeEventListener(RADAR_FILTER_CHANGE_EVENT, onFilterChange);
+      window.removeEventListener(REGION_CHANGE_EVENT, onRegionChange);
     };
   }, []);
 
@@ -91,11 +106,11 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
     writeRadarFilter(filter);
   }, [filter]);
 
-  // Fetch (re-fetch when filter changes). Each request is small + edge-cached
-  // for 5 min so flipping filters is cheap.
+  // Fetch (re-fetch when filter or region pref changes). Each request is
+  // small + edge-cached for 5 min so flipping filters or region is cheap.
   useEffect(() => {
     let cancelled = false;
-    const qs = buildQueryString(filter);
+    const qs = buildQueryString(filter, regionId);
     (async () => {
       try {
         const r = await fetch(`/api/hotzones?${qs}`, { cache: "no-store" });
@@ -113,7 +128,7 @@ export function HotZoneLayer({ map, bottomBoost = 0, learning }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [filter]);
+  }, [filter, regionId]);
 
   // ── Effect A: add the source + heatmap layer once when the map is
   // ready. The previous version used map.once("idle", …), but `idle`

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -11,12 +11,24 @@ export type RegionId =
   | "spokane"
   | "all_wa";
 
+/** Bounding box for a region. `null` means unfiltered (whole-state view). */
+export type RegionBbox = {
+  latMin: number;
+  latMax: number;
+  lonMin: number;
+  lonMax: number;
+} | null;
+
 export type Region = {
   id: RegionId;
   label: string;
   centerLat: number;
   centerLon: number;
   zoomLevel: number;
+  /** BBox used by /api/hotzones to filter heat cells to this region.
+   *  Generous-but-bounded boxes — a Spokane rider should still see the
+   *  occasional Pullman or Cheney patrol, just not Puget Sound. */
+  bbox: RegionBbox;
 };
 
 export const REGIONS: Record<RegionId, Region> = {
@@ -26,6 +38,7 @@ export const REGIONS: Record<RegionId, Region> = {
     centerLat: 47.6,
     centerLon: -122.3,
     zoomLevel: 9,
+    bbox: { latMin: 46.5, latMax: 48.5, lonMin: -123.5, lonMax: -121.5 },
   },
   pierce: {
     id: "pierce",
@@ -33,6 +46,7 @@ export const REGIONS: Record<RegionId, Region> = {
     centerLat: 47.05,
     centerLon: -122.3,
     zoomLevel: 10,
+    bbox: { latMin: 46.7, latMax: 47.4, lonMin: -122.9, lonMax: -121.6 },
   },
   snohomish: {
     id: "snohomish",
@@ -40,6 +54,7 @@ export const REGIONS: Record<RegionId, Region> = {
     centerLat: 48.0,
     centerLon: -121.9,
     zoomLevel: 10,
+    bbox: { latMin: 47.65, latMax: 48.4, lonMin: -122.55, lonMax: -121.0 },
   },
   spokane: {
     id: "spokane",
@@ -47,6 +62,7 @@ export const REGIONS: Record<RegionId, Region> = {
     centerLat: 47.66,
     centerLon: -117.43,
     zoomLevel: 10,
+    bbox: { latMin: 47.2, latMax: 48.1, lonMin: -118.2, lonMax: -116.7 },
   },
   all_wa: {
     id: "all_wa",
@@ -54,6 +70,7 @@ export const REGIONS: Record<RegionId, Region> = {
     centerLat: 47.4,
     centerLon: -120.5,
     zoomLevel: 7,
+    bbox: null,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `bbox` field to each Region (`null` for All-WA).
- /api/hotzones accepts new `region_id` query param; filters cells to the matching bbox.
- HotZoneLayer subscribes to region-pref change event and passes `region_id` with every fetch.
- Legacy `region` param still works (back-compat for the chevron filter); `region_id` wins when both are present.

## Test plan
- [ ] Switch RegionSelector to Spokane → heatmap recomputes to eastern WA cells only.
- [ ] Switch back to Puget Sound → heatmap recomputes to Puget Sound cells only.
- [ ] Chevron filter "All WA" still shows everything (no regression).
- [ ] curl /api/hotzones?region_id=spokane → only eastern WA zones in JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)