### PR TITLE
fix(hotzones): "Smokey" filter is role-based, not hardcoded tails

### DIFF
--- a/app/api/hotzones/route.ts
+++ b/app/api/hotzones/route.ts
@@ -49,20 +49,29 @@ export async function GET(req: Request) {
   const { regionId, bbox } = resolveBbox(url);
   const tails = parseList(url.searchParams.get("tails"));
   const operator = url.searchParams.get("operator")?.trim() ?? null;
+  // "Smokey" filter resolves through here as ?roles=smokey,patrol — the
+  // registry lookup expands the role set to the current matching tails
+  // so the rider's filter follows fleet membership changes automatically.
+  const roles = parseList(url.searchParams.get("roles")).map((r) =>
+    r.toLowerCase(),
+  );
 
   const [allZones, lastRefresh] = await Promise.all([
     getHotZonesCached(),
     getLastHotZoneRefresh(),
   ]);
 
-  // Build effective tail set from operator if specified.
+  // Build effective tail set from operator + roles if specified.
   let allowedTails: Set<string> | null = null;
-  if (tails.length > 0 || operator) {
+  if (tails.length > 0 || operator || roles.length > 0) {
     allowedTails = new Set(tails);
-    if (operator) {
+    if (operator || roles.length > 0) {
       const registry = await getRegistry();
       for (const f of registry) {
-        if (f.operator === operator) allowedTails.add(f.tail);
+        if (operator && f.operator === operator) allowedTails.add(f.tail);
+        if (roles.length > 0 && roles.includes(String(f.role).toLowerCase())) {
+          allowedTails.add(f.tail);
+        }
       }
     }
   }
@@ -80,6 +89,7 @@ export async function GET(req: Request) {
       region_id: regionId,
       filter_tails: tails,
       filter_operator: operator,
+      filter_roles: roles,
       total_unfiltered: allZones.length,
     },
     {

--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -18,7 +18,7 @@ import {
   DEFAULT_RADAR_FILTER,
   OPERATORS,
   RADAR_FILTER_CHANGE_EVENT,
-  SMOKY_TAILS,
+  SMOKY_FILTER_ROLES,
   readRadarFilter,
   writeRadarFilter,
   type RadarFilter as Filter,
@@ -44,7 +44,11 @@ function buildQueryString(f: Filter, regionId: RegionId): string {
   // when both are present.
   p.set("region_id", regionId);
   p.set("region", f.region);
-  if (f.showMode === "smoky") p.set("tails", SMOKY_TAILS.join(","));
+  // "Smokey" filter is role-based now (smokey + patrol). Server resolves
+  // the role list to the matching tail set via the registry, so adding
+  // a new fixed-wing smokey to the registry automatically widens the
+  // filter without a config change.
+  if (f.showMode === "smoky") p.set("roles", SMOKY_FILTER_ROLES.join(","));
   if (f.showMode === "operator" && f.operator) p.set("operator", f.operator);
   return p.toString();
 }

--- a/lib/radar-filter.ts
+++ b/lib/radar-filter.ts
@@ -21,7 +21,21 @@ export type RadarFilter = {
 export const RADAR_FILTER_KEY = "ss_hotzones_filter";
 export const RADAR_FILTER_CHANGE_EVENT = "ss-radar-filter-change";
 
-export const SMOKY_TAILS = ["N305DK", "N2446X"] as const;
+/**
+ * Roles that count as "Smokey" — speed-enforcement birds. The filter
+ * UI labels this "Smokey" because that's the rider mental model; the
+ * implementation matches by classified role, NOT a hardcoded tail list,
+ * so a new WSP smokey added to the registry is automatically included.
+ */
+export const SMOKY_FILTER_ROLES = ["smokey", "patrol"] as const;
+
+/**
+ * @deprecated Use SMOKY_FILTER_ROLES instead. Retained as an empty
+ * array so any prior import compiles, but no longer drives filtering
+ * — role-based classification (lib/types.ts FleetRole) is the source
+ * of truth.
+ */
+export const SMOKY_TAILS: readonly string[] = [];
 export const OPERATORS = [
   "WSP",
   "KCSO",
@@ -73,13 +87,14 @@ export function writeRadarFilter(f: RadarFilter): void {
 }
 
 export function passesAircraftFilter(
-  aircraft: { tail: string; operator: string },
+  aircraft: { tail: string; operator: string; role?: string },
   f: RadarFilter,
 ): boolean {
   if (f.showMode === "all") return true;
   if (f.showMode === "smoky") {
-    return SMOKY_TAILS.includes(
-      aircraft.tail as (typeof SMOKY_TAILS)[number],
+    return (
+      typeof aircraft.role === "string" &&
+      (SMOKY_FILTER_ROLES as readonly string[]).includes(aircraft.role)
     );
   }
   if (f.showMode === "operator" && f.operator) {


### PR DESCRIPTION
## Summary
Live-prod audit (Prompt 14, finding #10) confirmed: the "Smokey" chevron filter matched a hardcoded `SMOKY_TAILS = ["N305DK", "N2446X"]` array. Rider mental model is "speed-enforcement birds" — should be role-based so registry additions automatically widen the filter.

## Changes
- `lib/radar-filter.ts`: new `SMOKY_FILTER_ROLES = ["smokey", "patrol"]`; `passesAircraftFilter` now checks `aircraft.role`. `SMOKY_TAILS` kept as deprecated empty array for compile-compat.
- `components/HotZoneLayer.tsx`: sends `?roles=smokey,patrol` instead of `?tails=N305DK,N2446X`.
- `app/api/hotzones/route.ts`: accepts `?roles=` param; resolves through the registry (union with operator).

## Verification
Pre-fix evidence: `/tmp/p14-audit/findings.json` finding #10. Post-deploy verification: `curl '/api/hotzones?roles=smokey,patrol'` should return zones associated with all current smokey + patrol tails (not just the two hardcoded ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)