### PR TITLE
feat(home): bump header logo 20→32 for brand-mark prominence

### DIFF
--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -136,7 +136,7 @@ export function Glanceable({
             minWidth: 0,
           }}
         >
-          <Logo size={20} wordmark />
+          <Logo size={32} wordmark />
           <span
             className="ss-mono"
             style={{


### PR DESCRIPTION
## Summary
Live-prod audit finding #1: header logo measured 59×20px. Bumping from size=20 to size=32 makes the campaign-hat icon visibly the first element on the home page. Same layout, no new components.

## Verification
- Pre-fix: /tmp/p14-audit/01-home-brand.png
- Post-deploy: re-run \`npm run verify-prod\`; assertion #1 should pass with bounding box height ≥ 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)