### PR TITLE
feat(push): per-tail allow-list — pick specific Smokeys to follow

### DIFF
--- a/app/(tabs)/settings/alerts/page.tsx
+++ b/app/(tabs)/settings/alerts/page.tsx
@@ -1,6 +1,7 @@
 import { AlertsSettings } from "@/components/AlertsSettings";
 import { TimeFormatSetting } from "@/components/TimeFormatSetting";
 import { getTimeFormatPref } from "@/lib/user-prefs";
+import { getRegistry } from "@/lib/registry";
 
 export const metadata = {
   title: "Alerts",
@@ -9,11 +10,21 @@ export const metadata = {
 
 export const dynamic = "force-dynamic";
 
-export default function AlertsPage() {
-  const timeFormat = getTimeFormatPref();
+export default async function AlertsPage() {
+  const [timeFormat, registry] = await Promise.all([
+    Promise.resolve(getTimeFormatPref()),
+    getRegistry(),
+  ]);
   return (
     <>
-      <AlertsSettings />
+      <AlertsSettings
+        tails={registry.map((f) => ({
+          tail: f.tail,
+          nickname: f.nickname,
+          operator: f.operator,
+          role: f.role,
+        }))}
+      />
       <div
         style={{
           maxWidth: 460,

--- a/components/AlertsSettings.tsx
+++ b/components/AlertsSettings.tsx
@@ -26,7 +26,14 @@ import {
 
 type LoadState = "loading" | "ready";
 
-export function AlertsSettings() {
+export type TailOption = {
+  tail: string;
+  nickname: string | null;
+  operator: string;
+  role: string;
+};
+
+export function AlertsSettings({ tails: registry = [] }: { tails?: TailOption[] }) {
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [supported, setSupported] = useState(true);
   const [contextOk, setContextOk] = useState<{
@@ -278,6 +285,111 @@ export function AlertsSettings() {
               title="All aircraft"
               body="Every wing in the air."
             />
+          </Section>
+
+          {/* Tails — optional allow-list. Empty = all tails (subject to other
+              filters). Each row toggles a tail in/out of prefs.tails. */}
+          <Section eyebrow="Tails">
+            <p style={{ fontSize: 13, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.45 }}>
+              Pick specific tails to follow. Leave all unchecked to hear about
+              every bird that passes the tier filter.
+            </p>
+            <div
+              className="ss-mono"
+              style={{ fontSize: 10.5, color: SS_TOKENS.fg2, marginTop: 8, marginBottom: 6, letterSpacing: ".06em" }}
+            >
+              {!prefs.tails || prefs.tails.length === 0
+                ? "ALL TAILS"
+                : `${prefs.tails.length} TAIL${prefs.tails.length === 1 ? "" : "S"}`}
+            </div>
+            {registry.length === 0 ? (
+              <p style={{ fontSize: 12, color: SS_TOKENS.fg2, margin: 0 }}>
+                Registry unavailable.
+              </p>
+            ) : (
+              <div
+                role="group"
+                aria-label="Per-tail allow-list"
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  border: `.5px solid ${SS_TOKENS.hairline}`,
+                  borderRadius: 8,
+                  overflow: "hidden",
+                }}
+              >
+                {registry.map((t, i) => {
+                  const checked =
+                    Array.isArray(prefs.tails) &&
+                    prefs.tails.includes(t.tail.toUpperCase());
+                  return (
+                    <label
+                      key={t.tail}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 10,
+                        padding: "8px 12px",
+                        borderBottom:
+                          i === registry.length - 1
+                            ? 0
+                            : `.5px solid ${SS_TOKENS.hairline}`,
+                        cursor: "pointer",
+                        background: checked ? SS_TOKENS.bg2 : "transparent",
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => {
+                          const upper = t.tail.toUpperCase();
+                          const current = Array.isArray(prefs.tails)
+                            ? prefs.tails
+                            : [];
+                          const next = e.target.checked
+                            ? Array.from(new Set([...current, upper]))
+                            : current.filter((x) => x !== upper);
+                          // Empty array → drop the field so dispatcher
+                          // sees "no constraint" cleanly.
+                          persistPrefs({
+                            tails: next.length > 0 ? next : undefined,
+                          });
+                        }}
+                        style={{ flexShrink: 0 }}
+                      />
+                      <span
+                        className="ss-mono"
+                        style={{ fontSize: 12, fontWeight: 600, minWidth: 60 }}
+                      >
+                        {t.tail}
+                      </span>
+                      {t.nickname && (
+                        <span
+                          style={{
+                            fontSize: 12,
+                            color: SS_TOKENS.fg1,
+                            fontStyle: "italic",
+                          }}
+                        >
+                          &ldquo;{t.nickname}&rdquo;
+                        </span>
+                      )}
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: SS_TOKENS.fg2,
+                          marginLeft: "auto",
+                          textTransform: "uppercase",
+                          letterSpacing: ".04em",
+                        }}
+                      >
+                        {t.role}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
           </Section>
 
           {/* Zones (placeholder — per-zone opt-in needs hot-zone load; today is 'any') */}

--- a/lib/push/dispatcher.ts
+++ b/lib/push/dispatcher.ts
@@ -98,6 +98,7 @@ export async function dispatchTakeoff(
     const skip = shouldSkip(
       stored.prefs,
       args.role,
+      args.tail,
       args.lat,
       args.lon,
       aircraftZone,
@@ -150,12 +151,18 @@ function matchesUserZone(
 function shouldSkip(
   prefs: AlertPrefs,
   role: FleetRole,
+  tail: string,
   lat: number | null,
   lon: number | null,
   aircraftZone: string | null,
 ): boolean {
   // tier
   if (prefs.tier === "alert_only" && !ALERT_ROLES.has(role)) return true;
+  // tail allow-list — applied AFTER tier so a rider asking for "all
+  // tiers, only N305DK" still gets every transition for that tail.
+  if (Array.isArray(prefs.tails) && prefs.tails.length > 0) {
+    if (!prefs.tails.includes(tail.toUpperCase())) return true;
+  }
   // zone — predefined list AND/OR user-defined geofences. Any explicit
   // zone constraint imposes the gate; matching either kind passes it.
   // Empty constraints (no predefined + no user zones) means "any" — no gate.

--- a/lib/push/store.ts
+++ b/lib/push/store.ts
@@ -77,7 +77,23 @@ function mergePrefs(partial?: Partial<AlertPrefs>): AlertPrefs {
   };
   const userZones = sanitizeUserZones(partial.userZones);
   if (userZones !== undefined) merged.userZones = userZones;
+  const tails = sanitizeTails(partial.tails);
+  if (tails !== undefined) merged.tails = tails;
   return merged;
+}
+
+function sanitizeTails(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: string[] = [];
+  for (const t of v) {
+    if (typeof t !== "string") continue;
+    const upper = t.trim().toUpperCase();
+    // Tail format is loosely "N" + 1-5 alphanumerics. Permissive — we
+    // intersect with the registry at dispatch time so noise is harmless.
+    if (/^N[0-9A-Z]{1,5}$/.test(upper)) out.push(upper);
+  }
+  // Cap at 32 tails per subscriber — generous given our ~16-tail registry.
+  return Array.from(new Set(out)).slice(0, 32);
 }
 
 function clampHour(v: unknown, fallback: number): number {

--- a/lib/push/types.ts
+++ b/lib/push/types.ts
@@ -33,6 +33,13 @@ export type AlertPrefs = {
    * makes the takeoff eligible for that subscriber.
    */
   userZones?: UserZoneSpec[];
+  /**
+   * Optional per-tail allow-list. When present + non-empty, the dispatcher
+   * only fires for takeoffs of these specific tails (after tier filter).
+   * Empty / undefined = no tail restriction. Useful for riders who only
+   * care about a specific Smokey.
+   */
+  tails?: string[];
   /** Rider-local hour at which quiet hours START (24-hour, 0-23). */
   quiet_start_h: number;
   /** Rider-local hour at which quiet hours END (24-hour, 0-23). */


### PR DESCRIPTION
Adds AlertPrefs.tails?: string[] for the case where a rider only
cares about one or two specific birds (e.g. "I only want pings for
N305DK because that's the one in my commute corridor"). Empty /
undefined = no tail restriction (current behavior).

Storage (lib/push/types.ts + lib/push/store.ts):
  AlertPrefs.tails?: string[]; sanitizeTails validates the format
  (loose N + 1-5 alphanumerics, deduped, capped at 32). Cap is
  generous given the ~16-tail registry.

Dispatcher (lib/push/dispatcher.ts):
  shouldSkip now takes the takeoff tail. The tail filter is applied
  AFTER the tier filter so a rider who picks "all tiers, only
  N305DK" gets every transition for that tail.

UI (components/AlertsSettings.tsx + app/(tabs)/settings/alerts/page.tsx):
  New "Tails" section between Tier and Zones with a checkbox list
  rendered from the server-fetched registry. Status mono shows
  "ALL TAILS" when no constraint, "N TAILS" when set.

UX call (documenting the choice): checkbox list rather than multi-
select dropdown or typeahead. With ~16 tails, all options fit on
one screen and the rider can scan + check without combobox friction.
If the registry ever grows past ~30, revisit with a typeahead.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
