### PR TITLE
feat(radar): trail line behind each airborne aircraft

### DIFF
--- a/app/api/trails/route.ts
+++ b/app/api/trails/route.ts
@@ -1,0 +1,92 @@
+// /api/trails — recent track-history slice for currently-airborne tails.
+// Powers the polyline trail layer on /radar (components/AircraftTrailLayer).
+//
+// Query: GET /api/trails?tails=N305DK,N2446X&minutes=30
+// Response: { trails: { [tail]: [{ lat, lon, ts }] } }
+//   - Coordinates only (no alt/speed) — the trail layer doesn't need them
+//     and dropping fields keeps the payload small.
+//   - Sorted ascending by ts so a polyline reads from oldest → newest.
+
+import { NextResponse } from "next/server";
+import { getTracksForDay, listTrackKeys, type TrackPoint } from "@/lib/tracks";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_MINUTES = 30;
+const MAX_MINUTES = 240;
+const MAX_TAILS = 32;
+
+function utcDateKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+function parseTails(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => /^N[0-9A-Z]{1,5}$/.test(s))
+    .slice(0, MAX_TAILS);
+}
+
+type TrailPoint = { lat: number; lon: number; ts: number };
+
+async function trailFor(
+  tail: string,
+  cutoffSec: number,
+): Promise<TrailPoint[]> {
+  // Most trails fit inside today's UTC list; pull yesterday too only if
+  // the cutoff crosses midnight (rare with default 30 min window).
+  const now = new Date();
+  const todayKey = utcDateKey(now);
+  const yesterdayKey = utcDateKey(new Date(now.getTime() - 86_400_000));
+  const haveDates = await listTrackKeys(tail);
+  const interestingDates = haveDates.filter(
+    (d) => d === todayKey || d === yesterdayKey,
+  );
+  const allPoints: TrackPoint[] = [];
+  for (const date of interestingDates) {
+    const points = await getTracksForDay(tail, date);
+    for (const p of points) {
+      if (p.ts >= cutoffSec) allPoints.push(p);
+    }
+  }
+  allPoints.sort((a, b) => a.ts - b.ts);
+  return allPoints.map((p) => ({ lat: p.lat, lon: p.lon, ts: p.ts }));
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const tails = parseTails(url.searchParams.get("tails"));
+  const minutes = Math.min(
+    MAX_MINUTES,
+    Math.max(1, Number(url.searchParams.get("minutes") ?? DEFAULT_MINUTES)),
+  );
+  if (tails.length === 0) {
+    return NextResponse.json({ trails: {} });
+  }
+  const cutoffSec = Math.floor(Date.now() / 1000) - minutes * 60;
+  const entries = await Promise.all(
+    tails.map(async (t) => [t, await trailFor(t, cutoffSec)] as const),
+  );
+  const trails: Record<string, TrailPoint[]> = {};
+  for (const [tail, points] of entries) {
+    if (points.length > 0) trails[tail] = points;
+  }
+  return NextResponse.json(
+    { trails, minutes },
+    {
+      headers: {
+        // Trails update every ~10s on the client; cache for half that
+        // at the edge so two simultaneous radar viewers share a fetch
+        // but never see stale-by-more-than-a-poll data.
+        "Cache-Control":
+          "public, max-age=0, s-maxage=5, stale-while-revalidate=30",
+      },
+    },
+  );
+}

--- a/components/AircraftTrailLayer.tsx
+++ b/components/AircraftTrailLayer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+// Polls /api/trails for the currently-airborne tail set and renders a
+// gradient polyline behind each plane on /radar. Sits BELOW the
+// "aircraft" symbol layer so the chevron stays visually on top.
+//
+// Gradient: full-opacity sky-color at the head (most recent point) →
+// transparent at the tail end. We achieve this with a "line-gradient"
+// paint expression which requires the source's lineMetrics to be true.
+
+import { useEffect, useRef } from "react";
+import type { Map as MaplibreMap, GeoJSONSource } from "maplibre-gl";
+import { SS_TOKENS } from "@/lib/tokens";
+import type { Aircraft } from "@/lib/types";
+
+const SOURCE_ID = "aircraft-trails";
+const LAYER_ID = "aircraft-trail";
+const POLL_MS = 10_000;
+const TRAIL_MINUTES = 30;
+
+type TrailPoint = { lat: number; lon: number; ts: number };
+type TrailsResponse = { trails: Record<string, TrailPoint[]> };
+
+function buildFeatureCollection(
+  trails: Record<string, TrailPoint[]>,
+): GeoJSON.FeatureCollection<GeoJSON.LineString> {
+  const features: GeoJSON.Feature<GeoJSON.LineString>[] = [];
+  for (const [tail, pts] of Object.entries(trails)) {
+    if (pts.length < 2) continue;
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: pts.map((p) => [p.lon, p.lat]),
+      },
+      properties: { tail },
+    });
+  }
+  return { type: "FeatureCollection", features };
+}
+
+export function AircraftTrailLayer({
+  map,
+  airborne,
+}: {
+  map: MaplibreMap | null;
+  airborne: Aircraft[];
+}) {
+  const tailsKey = airborne
+    .map((a) => a.tail)
+    .filter(Boolean)
+    .sort()
+    .join(",");
+  const tailsKeyRef = useRef(tailsKey);
+  tailsKeyRef.current = tailsKey;
+
+  // Layer attachment — once per map instance.
+  useEffect(() => {
+    if (!map) return;
+    const attach = () => {
+      if (!map.isStyleLoaded() || map.getSource(SOURCE_ID)) return;
+      const beforeId = map.getLayer("aircraft") ? "aircraft" : undefined;
+      map.addSource(SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+        // lineMetrics=true is required for the line-gradient paint
+        // expression below to interpolate along the line length.
+        lineMetrics: true,
+      });
+      map.addLayer(
+        {
+          id: LAYER_ID,
+          type: "line",
+          source: SOURCE_ID,
+          layout: { "line-cap": "round", "line-join": "round" },
+          paint: {
+            "line-width": 2,
+            "line-gradient": [
+              "interpolate",
+              ["linear"],
+              ["line-progress"],
+              0,
+              "rgba(74,158,255,0)",
+              1,
+              SS_TOKENS.sky,
+            ],
+          },
+        },
+        beforeId,
+      );
+    };
+    if (map.isStyleLoaded()) attach();
+    map.on("load", attach);
+    map.on("styledata", attach);
+    return () => {
+      map.off("load", attach);
+      map.off("styledata", attach);
+      try {
+        if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
+        if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+      } catch {
+        // map torn down already
+      }
+    };
+  }, [map]);
+
+  // Poll /api/trails whenever the airborne tail set changes, plus every
+  // POLL_MS while it's stable. Cancel + restart cleanly if tails change
+  // mid-cycle so we never write a stale set to the source.
+  useEffect(() => {
+    if (!map) return;
+    if (!tailsKey) {
+      // No airborne tails — clear the layer.
+      const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+      if (src) src.setData({ type: "FeatureCollection", features: [] });
+      return;
+    }
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const r = await fetch(
+          `/api/trails?tails=${tailsKey}&minutes=${TRAIL_MINUTES}`,
+          { cache: "no-store" },
+        );
+        if (!r.ok || cancelled) return;
+        const d = (await r.json()) as TrailsResponse;
+        if (cancelled) return;
+        // Tails may have shifted while the fetch was in flight; bail if so
+        // to avoid painting stale data over a fresh-tail snapshot.
+        if (tailsKeyRef.current !== tailsKey) return;
+        const src = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+        if (src) src.setData(buildFeatureCollection(d.trails ?? {}));
+      } catch {
+        // transient — try again next tick
+      }
+    };
+    fetchOnce();
+    const id = window.setInterval(fetchOnce, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [map, tailsKey]);
+
+  return null;
+}

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -11,6 +11,7 @@ import { StatusPill } from "./StatusPill";
 import { SpottedButton } from "./SpottedButton";
 import { HotZoneLayer } from "./HotZoneLayer";
 import { UserZoneLayer } from "./UserZoneLayer";
+import { AircraftTrailLayer } from "./AircraftTrailLayer";
 import { addUserZone } from "@/lib/user-zones";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
@@ -166,6 +167,7 @@ export function RadarShell({
         learning={learning}
       />
       <UserZoneLayer map={map} />
+      <AircraftTrailLayer map={map} airborne={airborne} />
       <AddZoneButton
         rider={rider}
         onAdded={(label) => flashToast(setToast, `Zone "${label}" added`)}


### PR DESCRIPTION
Live-prod audit (Prompt 14, finding #2) confirmed: no trail line
existed behind aircraft on /radar — claimed in earlier prompts but
never actually shipped.

Now: a thin sky-color polyline reads from the plane's last 30 minutes
of recorded positions, gradient fading to transparent at the older
end so the head visually anchors at the chevron and the tail dissolves.
Sits BELOW the aircraft symbol layer so chevrons stay on top.

Server (app/api/trails/route.ts):
  GET /api/trails?tails=N305DK,N2446X&minutes=30 → coordinates only,
  sorted ascending by ts. Pulls today + yesterday from KV (the 30-min
  window crosses midnight rarely; covered when it does). Edge cache
  s-maxage=5 so two simultaneous radar viewers share fetches.

Client (components/AircraftTrailLayer.tsx):
  Polls every 10s when there's an airborne tail set; keys cleanly off
  the sorted tail list so a tail dropping out cancels the in-flight
  fetch instead of overwriting fresh data with stale. lineMetrics=true
  on the source enables the line-progress paint expression.

Wired in RadarShell alongside UserZoneLayer + HotZoneLayer.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
