### PR TITLE
feat(alerts): foreground proximity alert when alert-tier tail nearby

### DIFF
--- a/components/AlertsSettings.tsx
+++ b/components/AlertsSettings.tsx
@@ -23,6 +23,13 @@ import {
   type AlertPrefs,
   type AlertTier,
 } from "@/lib/push/types";
+import {
+  DEFAULT_PROXIMITY_NM,
+  getProximityThresholdNm,
+  isProximityEnabled,
+  setProximityEnabled,
+  setProximityThresholdNm,
+} from "@/lib/proximity-alert";
 
 type LoadState = "loading" | "ready";
 
@@ -45,6 +52,13 @@ export function AlertsSettings({ tails: registry = [] }: { tails?: TailOption[] 
   const [prefs, setPrefs] = useState<AlertPrefs>(DEFAULT_PREFS);
   const [toast, setToast] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [proximityOn, setProximityOn] = useState<boolean>(false);
+  const [proximityNm, setProximityNm] = useState<number>(DEFAULT_PROXIMITY_NM);
+  // Hydrate proximity prefs from localStorage on mount.
+  useEffect(() => {
+    setProximityOn(isProximityEnabled());
+    setProximityNm(getProximityThresholdNm());
+  }, []);
 
   // Hydrate from current SW state on mount.
   useEffect(() => {
@@ -405,6 +419,73 @@ export function AlertsSettings({ tails: registry = [] }: { tails?: TailOption[] 
               {prefs.zones === "any"
                 ? "ANY ZONE"
                 : `${prefs.zones.length} ZONE${prefs.zones.length === 1 ? "" : "S"}`}
+            </div>
+          </Section>
+
+          {/* Proximity (foreground-only, client-side) — fires a local
+              notification when an alert-tier tail enters the threshold
+              while the app is open + GPS granted. No server-side rider
+              position; pure client logic. */}
+          <Section eyebrow="Proximity">
+            <p style={{ fontSize: 13, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.45 }}>
+              While the app is open and GPS is granted, ping me when a
+              tracked bird gets within range.
+            </p>
+            <div
+              style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 10 }}
+            >
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={proximityOn}
+                  onChange={(e) => {
+                    const next = e.target.checked;
+                    setProximityOn(next);
+                    setProximityEnabled(next);
+                  }}
+                />
+                <span className="ss-mono" style={{ fontSize: 12, letterSpacing: ".04em" }}>
+                  ENABLED
+                </span>
+              </label>
+              <span style={{ flex: 1 }} />
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={proximityNm}
+                onChange={(e) => {
+                  const n = Number(e.target.value);
+                  if (Number.isFinite(n) && n > 0) {
+                    setProximityNm(n);
+                    setProximityThresholdNm(n);
+                  }
+                }}
+                disabled={!proximityOn}
+                aria-label="Proximity threshold in nautical miles"
+                style={{
+                  width: 56,
+                  padding: "6px 8px",
+                  background: SS_TOKENS.bg2,
+                  border: `.5px solid ${SS_TOKENS.hairline2}`,
+                  borderRadius: 6,
+                  color: SS_TOKENS.fg0,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 13,
+                  textAlign: "right",
+                  opacity: proximityOn ? 1 : 0.5,
+                }}
+              />
+              <span className="ss-mono" style={{ fontSize: 11, color: SS_TOKENS.fg2 }}>
+                NM
+              </span>
             </div>
           </Section>
 

--- a/components/RadarShell.tsx
+++ b/components/RadarShell.tsx
@@ -13,6 +13,12 @@ import { HotZoneLayer } from "./HotZoneLayer";
 import { UserZoneLayer } from "./UserZoneLayer";
 import { AircraftTrailLayer } from "./AircraftTrailLayer";
 import { addUserZone } from "@/lib/user-zones";
+import {
+  detectProximityHits,
+  fireProximityNotifications,
+  getProximityThresholdNm,
+  isProximityEnabled,
+} from "@/lib/proximity-alert";
 import { HelpIcon } from "./HelpIcon";
 import { Tooltip } from "./Tooltip";
 import { FreshnessLabel } from "./FreshnessLabel";
@@ -126,6 +132,25 @@ export function RadarShell({
       showRings ? "1" : "0",
     );
   }, [showRings]);
+
+  // Foreground proximity alerts. Runs whenever snap.aircraft changes
+  // (every poll cycle from useAircraft) — when a tracked alert-tier
+  // tail enters the rider's threshold, fire a local notification via
+  // the SW. No server-side rider position storage; pure client logic.
+  // Per-tail cooldown lives in localStorage to prevent re-firing
+  // every 10s while a plane orbits within range.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (document.visibilityState !== "visible") return;
+    if (!rider) return;
+    if (!isProximityEnabled()) return;
+    const hits = detectProximityHits(
+      snap.aircraft,
+      rider,
+      getProximityThresholdNm(),
+    );
+    if (hits.length > 0) void fireProximityNotifications(hits);
+  }, [snap.aircraft, rider]);
 
   // Geolocation only kicks in when this component mounts — i.e. when the user
   // actually visits /radar. The home page never asks.

--- a/lib/proximity-alert.ts
+++ b/lib/proximity-alert.ts
@@ -1,0 +1,136 @@
+// Foreground proximity alerts. When the rider's GPS is granted AND a
+// tracked alert-tier (smokey | patrol | unknown) tail enters within
+// the configured nm threshold, fire a local notification via the
+// service worker. No server-side rider position storage — this is
+// pure client-side logic per CLAUDE.md privacy posture.
+//
+// Per-tail cooldown via localStorage prevents re-firing on every
+// 10s poll while a plane orbits within the threshold.
+
+"use client";
+
+import { haversineNm } from "./geo";
+import type { Aircraft, FleetRole } from "./types";
+
+export const PROXIMITY_THRESHOLD_KEY = "ss_proximity_threshold_nm";
+export const PROXIMITY_ENABLED_KEY = "ss_proximity_enabled";
+export const DEFAULT_PROXIMITY_NM = 5;
+const COOLDOWN_MS = 15 * 60 * 1000;
+const COOLDOWN_PREFIX = "ss_proximity_seen:";
+
+const ALERT_ROLES: ReadonlySet<FleetRole> = new Set([
+  "smokey",
+  "patrol",
+  "unknown",
+]);
+
+export function getProximityThresholdNm(): number {
+  if (typeof window === "undefined") return DEFAULT_PROXIMITY_NM;
+  const raw = window.localStorage.getItem(PROXIMITY_THRESHOLD_KEY);
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 50) return DEFAULT_PROXIMITY_NM;
+  return n;
+}
+
+export function setProximityThresholdNm(nm: number): void {
+  if (typeof window === "undefined") return;
+  const clamped = Math.max(1, Math.min(50, Math.round(nm)));
+  window.localStorage.setItem(PROXIMITY_THRESHOLD_KEY, String(clamped));
+}
+
+export function isProximityEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(PROXIMITY_ENABLED_KEY) === "1";
+}
+
+export function setProximityEnabled(on: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(PROXIMITY_ENABLED_KEY, on ? "1" : "0");
+}
+
+function recentlySeen(tail: string): boolean {
+  if (typeof window === "undefined") return false;
+  const raw = window.localStorage.getItem(`${COOLDOWN_PREFIX}${tail}`);
+  if (!raw) return false;
+  const ts = Number(raw);
+  if (!Number.isFinite(ts)) return false;
+  return Date.now() - ts < COOLDOWN_MS;
+}
+
+function markSeen(tail: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(`${COOLDOWN_PREFIX}${tail}`, String(Date.now()));
+}
+
+export type ProximityHit = {
+  tail: string;
+  nickname: string | null;
+  role: FleetRole;
+  distanceNm: number;
+};
+
+/**
+ * Returns alert-tier aircraft inside the threshold that haven't fired
+ * a notification within the cooldown window. Caller is responsible for
+ * actually firing notifications and (on success) calling markSeen.
+ */
+export function detectProximityHits(
+  aircraft: Aircraft[],
+  rider: { lat: number; lon: number },
+  thresholdNm: number,
+): ProximityHit[] {
+  const hits: ProximityHit[] = [];
+  for (const a of aircraft) {
+    if (!a.airborne) continue;
+    if (a.lat == null || a.lon == null) continue;
+    if (!ALERT_ROLES.has(a.role)) continue;
+    if (recentlySeen(a.tail)) continue;
+    const d = haversineNm(rider.lat, rider.lon, a.lat, a.lon);
+    if (d <= thresholdNm) {
+      hits.push({
+        tail: a.tail,
+        nickname: a.nickname,
+        role: a.role,
+        distanceNm: d,
+      });
+    }
+  }
+  return hits;
+}
+
+/**
+ * Fire a local SW notification for each new proximity hit. Returns the
+ * count of notifications successfully posted. Per-tail cooldown is
+ * recorded only on successful post so a transient SW failure doesn't
+ * silently swallow the next opportunity.
+ */
+export async function fireProximityNotifications(
+  hits: ProximityHit[],
+): Promise<number> {
+  if (hits.length === 0) return 0;
+  if (typeof window === "undefined") return 0;
+  if (!("serviceWorker" in navigator)) return 0;
+  if (typeof Notification === "undefined") return 0;
+  if (Notification.permission !== "granted") return 0;
+  const reg = await navigator.serviceWorker.getRegistration();
+  if (!reg) return 0;
+  let posted = 0;
+  for (const h of hits) {
+    const name = h.nickname ?? h.tail;
+    const dist = h.distanceNm.toFixed(1);
+    try {
+      await reg.showNotification(`${name} nearby`, {
+        body: `${dist} nm out. ${h.role === "smokey" ? "Watching." : "Eyes up."}`,
+        icon: "/icons/icon-192.png",
+        badge: "/icons/favicon-96.png",
+        tag: `proximity-${h.tail}`,
+        data: { url: `/plane/${h.tail}`, tail: h.tail, kind: "proximity" },
+      });
+      markSeen(h.tail);
+      posted += 1;
+    } catch {
+      // Best-effort. Don't markSeen on failure.
+    }
+  }
+  return posted;
+}


### PR DESCRIPTION
Closes Prompt 14 Phase 4.3. When the rider has /radar open AND GPS
granted AND a tracked smokey/patrol/unknown tail is within the
configured nm threshold, fire a local notification via the SW.

Decision (locked per CLAUDE.md privacy posture): client-side only.
No server-side rider-position storage — the dispatcher's user-zone
routing (PR #44) covers the background-push case at zone granularity;
this proximity alert is the foreground "actually nearby right now"
signal that doesn't need a server roundtrip.

Architecture (lib/proximity-alert.ts):
  - getProximityThresholdNm / setProximityThresholdNm — clamped 1-50
    nm, default 5 nm, localStorage-backed.
  - isProximityEnabled / setProximityEnabled — feature toggle.
  - detectProximityHits — pure function over (aircraft, rider, threshold)
    returning alert-tier tails inside the threshold whose per-tail
    cooldown (15 min) hasn't fired.
  - fireProximityNotifications — posts via reg.showNotification, marks
    seen only on success. SW failure leaves the cooldown clear so the
    next opportunity isn't silently swallowed.

RadarShell hook: runs on every snap.aircraft change while the page is
visible. visibility check prevents background ticking from the focus
poll.

UI (AlertsSettings.tsx): new "Proximity" section between Tails/Zones
and Quiet hours — a checkbox + nm number input. Disabled state ramps
the input opacity so the toggle/threshold relationship reads at a
glance.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
