### PR TITLE
feat(layout): responsive page-width for /, /activity, /about on desktop

### DIFF
--- a/app/(tabs)/about/page.tsx
+++ b/app/(tabs)/about/page.tsx
@@ -19,14 +19,13 @@ export default async function AboutPage() {
   const fleet = await getRegistry();
   return (
     <main
+      className="ss-page-narrow"
       style={{
         minHeight: "100dvh",
         padding: "12px 18px 60px",
         display: "flex",
         flexDirection: "column",
         gap: 18,
-        maxWidth: 460,
-        margin: "0 auto",
       }}
     >
       <header

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,6 +142,29 @@ body {
   transform: translateY(0);
 }
 
+/* Responsive page-width container — mobile-first 460 px column that
+   widens at tablet (>= 768 px) and desktop (>= 1280 px) so home /
+   activity / about / about-equivalent pages stop rendering as a
+   narrow strip on a wide monitor. Apply with className="ss-page-narrow"
+   instead of inline maxWidth so the breakpoints work without per-page
+   useEffect / window watcher. */
+.ss-page-narrow {
+  max-width: 460px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .ss-page-narrow {
+    max-width: 720px;
+  }
+}
+@media (min-width: 1280px) {
+  .ss-page-narrow {
+    max-width: 960px;
+  }
+}
+
 /* Respect prefers-reduced-motion: kill the pulsers + transitions. */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -38,11 +38,10 @@ export function ActivityFeed({ initial }: { initial: ActivityEntry[] }) {
 
   return (
     <main
+      className="ss-page-narrow"
       style={{
         minHeight: "100dvh",
         padding: `12px 18px ${TABBAR_HEIGHT + 24}px`,
-        maxWidth: 460,
-        margin: "0 auto",
         display: "flex",
         flexDirection: "column",
         gap: 14,

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -103,15 +103,13 @@ export function Glanceable({
 
   return (
     <main
-      className="ss-hero-bg"
+      className="ss-hero-bg ss-page-narrow"
       style={{
         minHeight: "100dvh",
         padding: "12px 18px 100px",
         display: "flex",
         flexDirection: "column",
         gap: 16,
-        maxWidth: 460,
-        margin: "0 auto",
       }}
     >
       <HelpIcon />


### PR DESCRIPTION
Live-prod audit (Prompt 14, finding #8) measured the home page <main>
at 460px on a 1280px viewport — mobile-shaped on desktop. Same fixed
maxWidth used in /activity and /about.

New .ss-page-narrow utility in globals.css:
  default      max-width: 460px   (mobile, current behavior)
  ≥768 px      max-width: 720px   (tablet)
  ≥1280 px     max-width: 960px   (desktop)

Replaces inline maxWidth on Glanceable, ActivityFeed, and the about
page with className="ss-page-narrow". Mobile renders unchanged at
460 px; desktop now uses available width.

Multi-column layouts (home as 2-col landing, activity with side
metadata, about wider narrative) are deliberately deferred — that's
substantial JSX restructuring per page. This PR is the smallest
move that gets desktop visitors out of the 460-px-on-1920-px box.

Other layouts intentionally kept at fixed 460 px:
- /dash (per-glance dense, looks worse stretched)
- /plane/[tail] (single-column detail page)
- /settings/alerts (form-heavy, looks worse stretched)
- /legal (narrative width well-served at 460)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
