### PR TITLE
feat(a11y): NX1 high-contrast variant

### DIFF
--- a/app/(tabs)/settings/alerts/actions.ts
+++ b/app/(tabs)/settings/alerts/actions.ts
@@ -2,7 +2,12 @@
 
 import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
-import { TIME_FORMAT_COOKIE, type TimeFormat } from "@/lib/user-prefs";
+import {
+  CONTRAST_COOKIE,
+  TIME_FORMAT_COOKIE,
+  type ContrastMode,
+  type TimeFormat,
+} from "@/lib/user-prefs";
 
 const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
 
@@ -21,5 +26,20 @@ export async function setTimeFormatAction(formData: FormData): Promise<void> {
   });
   // Revalidate every page that renders times so the new format takes effect
   // on the next paint instead of waiting for a navigation.
+  revalidatePath("/", "layout");
+}
+
+/** Persist contrast variant. Same cookie pattern as time format. */
+export async function setContrastAction(formData: FormData): Promise<void> {
+  const raw = formData.get("contrast");
+  const next: ContrastMode = raw === "high" ? "high" : "normal";
+  cookies().set({
+    name: CONTRAST_COOKIE,
+    value: next,
+    path: "/",
+    maxAge: ONE_YEAR_SECONDS,
+    sameSite: "lax",
+    httpOnly: false,
+  });
   revalidatePath("/", "layout");
 }

--- a/app/(tabs)/settings/alerts/page.tsx
+++ b/app/(tabs)/settings/alerts/page.tsx
@@ -1,6 +1,7 @@
 import { AlertsSettings } from "@/components/AlertsSettings";
+import { ContrastSetting } from "@/components/ContrastSetting";
 import { TimeFormatSetting } from "@/components/TimeFormatSetting";
-import { getTimeFormatPref } from "@/lib/user-prefs";
+import { getContrastPref, getTimeFormatPref } from "@/lib/user-prefs";
 import { getRegistry } from "@/lib/registry";
 
 export const metadata = {
@@ -11,8 +12,9 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function AlertsPage() {
-  const [timeFormat, registry] = await Promise.all([
+  const [timeFormat, contrast, registry] = await Promise.all([
     Promise.resolve(getTimeFormatPref()),
+    Promise.resolve(getContrastPref()),
     getRegistry(),
   ]);
   return (
@@ -28,11 +30,20 @@ export default async function AlertsPage() {
       <div
         style={{
           maxWidth: 460,
-          margin: "16px auto 80px",
+          margin: "16px auto 0",
           padding: "0 18px",
         }}
       >
         <TimeFormatSetting current={timeFormat} />
+      </div>
+      <div
+        style={{
+          maxWidth: 460,
+          margin: "16px auto 80px",
+          padding: "0 18px",
+        }}
+      >
+        <ContrastSetting current={contrast} />
       </div>
     </>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,18 @@
   --ss-hairline-2: rgba(255, 255, 255, 0.10);
 }
 
+/* High-contrast variant — stays dark, lifts secondary text + hairline
+   opacity so meta-lines and dividers stay legible in glare or low-vision
+   conditions. Brand alert/clear/sky/warn semantic colors NOT changed —
+   they're the same hue everyone learns to recognize on the radar. */
+body[data-contrast="high"] {
+  --ss-fg1: #D0D5DD;
+  --ss-fg2: #B0B7C2;
+  --ss-fg3: #6B7380;
+  --ss-hairline: rgba(255, 255, 255, 0.14);
+  --ss-hairline-2: rgba(255, 255, 255, 0.22);
+}
+
 html,
 body {
   background: var(--ss-bg0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { BASE_URL } from "@/lib/config";
 import { IOSInstallPrompt } from "@/components/IOSInstallPrompt";
 import { SwRegistrar } from "@/components/SwRegistrar";
 import { TooltipProvider } from "@/components/Tooltip";
+import { getContrastPref } from "@/lib/user-prefs";
 import "./globals.css";
 
 const inter = Inter({
@@ -81,9 +82,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const contrast = getContrastPref();
   return (
     <html lang="en" className={`${inter.variable} ${mono.variable}`}>
-      <body className="ss-app bg-ss-bg0 text-ss-fg0">
+      <body
+        className="ss-app bg-ss-bg0 text-ss-fg0"
+        data-contrast={contrast}
+      >
         <TooltipProvider>
           {children}
           <IOSInstallPrompt />

--- a/components/ContrastSetting.tsx
+++ b/components/ContrastSetting.tsx
@@ -1,0 +1,108 @@
+import { SS_TOKENS } from "@/lib/tokens";
+import { type ContrastMode } from "@/lib/user-prefs";
+import { setContrastAction } from "@/app/(tabs)/settings/alerts/actions";
+
+export function ContrastSetting({ current }: { current: ContrastMode }) {
+  return (
+    <section
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 14,
+        padding: "16px 18px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <div>
+        <div
+          className="ss-mono"
+          style={{
+            fontSize: 9.5,
+            color: SS_TOKENS.fg2,
+            letterSpacing: ".12em",
+            textTransform: "uppercase",
+            marginBottom: 6,
+          }}
+        >
+          Display
+        </div>
+        <h2
+          style={{
+            fontSize: 18,
+            fontWeight: 700,
+            color: SS_TOKENS.fg0,
+            margin: 0,
+            letterSpacing: "-.01em",
+          }}
+        >
+          Contrast
+        </h2>
+        <p
+          style={{
+            fontSize: 13,
+            color: SS_TOKENS.fg1,
+            lineHeight: 1.5,
+            marginTop: 6,
+            marginBottom: 0,
+          }}
+        >
+          Stays dark either way. High lifts secondary text and dividers for
+          glare or low-vision conditions.
+        </p>
+      </div>
+
+      <form
+        action={setContrastAction}
+        style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
+      >
+        <Choice value="normal" current={current} label="Normal" />
+        <Choice value="high" current={current} label="High" />
+      </form>
+    </section>
+  );
+}
+
+function Choice({
+  value,
+  current,
+  label,
+}: {
+  value: ContrastMode;
+  current: ContrastMode;
+  label: string;
+}) {
+  const active = current === value;
+  return (
+    <button
+      type="submit"
+      name="contrast"
+      value={value}
+      aria-pressed={active}
+      style={{
+        flex: 1,
+        minWidth: 140,
+        padding: "12px 14px",
+        borderRadius: 12,
+        border: `.5px solid ${active ? SS_TOKENS.alert : SS_TOKENS.hairline2}`,
+        background: active ? SS_TOKENS.alertDim : SS_TOKENS.bg2,
+        color: SS_TOKENS.fg0,
+        cursor: "pointer",
+        textAlign: "left",
+      }}
+    >
+      <span
+        className="ss-mono"
+        style={{
+          fontSize: 12,
+          letterSpacing: ".06em",
+          color: active ? SS_TOKENS.alert : SS_TOKENS.fg1,
+          fontWeight: 700,
+        }}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}

--- a/lib/user-prefs.ts
+++ b/lib/user-prefs.ts
@@ -18,3 +18,18 @@ export function getTimeFormatPref(): TimeFormat {
 export function isHour12(pref: TimeFormat): boolean {
   return pref === "12";
 }
+
+// Contrast variant. We do NOT ship light mode — high-contrast stays
+// dark, just lifts secondary text + hairline opacity so WCAG-AAA-leaning
+// riders (or daytime-glare conditions) read the meta lines and dividers
+// reliably. Stored via the same cookie pattern as TIME_FORMAT_COOKIE so
+// the SSR/CSR rendered HTML stays identical.
+export const CONTRAST_COOKIE = "ss_contrast";
+export type ContrastMode = "normal" | "high";
+export const DEFAULT_CONTRAST: ContrastMode = "normal";
+
+/** Read the rider's preferred contrast mode. Server Components only. */
+export function getContrastPref(): ContrastMode {
+  const v = cookies().get(CONTRAST_COOKIE)?.value;
+  return v === "high" ? "high" : DEFAULT_CONTRAST;
+}


### PR DESCRIPTION
## Summary
- Adds a **Contrast** section in `/settings/alerts` with Normal | High choice (mirrors the Time-format pattern).
- Stays dark — high-contrast lifts secondary text (`--ss-fg1/2/3`) + hairline opacity for glare or low-vision conditions.
- Brand semantic colors (alert amber, clear green, sky blue, danger red) **not** changed.
- Cookie `ss_contrast`, server-read in `app/layout.tsx` → `<body data-contrast="high">`. No SSR/CSR mismatch.

## Test plan
- [ ] `/settings/alerts` shows the new Contrast section
- [ ] Toggling Normal ↔ High persists across reload
- [ ] In High mode, body's `data-contrast="high"` and meta text + dividers are visibly stronger
- [ ] No new client JS for the toggle (form submits to server action)
- [ ] Brand alert orange unchanged in either mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)