### PR TITLE
feat(alerts): NX4 voice readback for foreground alerts

### DIFF
--- a/components/AlertsSettings.tsx
+++ b/components/AlertsSettings.tsx
@@ -30,6 +30,12 @@ import {
   setProximityEnabled,
   setProximityThresholdNm,
 } from "@/lib/proximity-alert";
+import {
+  isVoiceModeEnabled,
+  isVoiceModeSupported,
+  setVoiceModeEnabled,
+  speakAlert,
+} from "@/lib/voice-mode";
 
 type LoadState = "loading" | "ready";
 
@@ -54,10 +60,14 @@ export function AlertsSettings({ tails: registry = [] }: { tails?: TailOption[] 
   const [busy, setBusy] = useState(false);
   const [proximityOn, setProximityOn] = useState<boolean>(false);
   const [proximityNm, setProximityNm] = useState<number>(DEFAULT_PROXIMITY_NM);
+  const [voiceOn, setVoiceOn] = useState<boolean>(false);
+  const [voiceSupported, setVoiceSupported] = useState<boolean>(true);
   // Hydrate proximity prefs from localStorage on mount.
   useEffect(() => {
     setProximityOn(isProximityEnabled());
     setProximityNm(getProximityThresholdNm());
+    setVoiceOn(isVoiceModeEnabled());
+    setVoiceSupported(isVoiceModeSupported());
   }, []);
 
   // Hydrate from current SW state on mount.
@@ -498,6 +508,55 @@ export function AlertsSettings({ tails: registry = [] }: { tails?: TailOption[] 
               <span className="ss-mono" style={{ fontSize: 11, color: SS_TOKENS.fg2 }}>
                 NM
               </span>
+            </div>
+          </Section>
+
+          {/* Voice readback (NX4) — when an alert fires while the page
+              is open, speak the body via speechSynthesis. iOS needs a
+              user gesture before the first speak() works; the toggle
+              click + the test-notification flow both prime the API. */}
+          <Section eyebrow="Voice">
+            <p style={{ fontSize: 13, color: SS_TOKENS.fg1, margin: 0, lineHeight: 1.45 }}>
+              Read alerts aloud while the page is open. Useful with helmet
+              audio. Closed-tab background pings don't speak.
+            </p>
+            <div
+              style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 10 }}
+            >
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  cursor: voiceSupported ? "pointer" : "not-allowed",
+                  opacity: voiceSupported ? 1 : 0.5,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={voiceOn}
+                  disabled={!voiceSupported}
+                  onChange={(e) => {
+                    const next = e.target.checked;
+                    setVoiceOn(next);
+                    setVoiceModeEnabled(next);
+                    // Prime the API on first opt-in so iOS allows
+                    // subsequent speak() calls without user gesture.
+                    if (next) speakAlert("Voice readback on.");
+                  }}
+                />
+                <span className="ss-mono" style={{ fontSize: 12, letterSpacing: ".04em" }}>
+                  ENABLED
+                </span>
+              </label>
+              {!voiceSupported && (
+                <span
+                  className="ss-mono"
+                  style={{ fontSize: 11, color: SS_TOKENS.fg2 }}
+                >
+                  UNSUPPORTED
+                </span>
+              )}
             </div>
           </Section>
 

--- a/components/SwRegistrar.tsx
+++ b/components/SwRegistrar.tsx
@@ -8,6 +8,7 @@
 // gets a registration handle as early as the JS bundle hydrates.
 
 import { useEffect } from "react";
+import { speakAlert } from "@/lib/voice-mode";
 
 export function SwRegistrar() {
   useEffect(() => {
@@ -16,6 +17,17 @@ export function SwRegistrar() {
     navigator.serviceWorker.register("/sw.js").catch(() => {
       /* silent — PWA install + push will fail gracefully if SW can't register */
     });
+    // Voice readback bridge — SW posts title/body on every push so we
+    // can speak it. speakAlert no-ops when voice mode is off.
+    const onMsg = (e: MessageEvent) => {
+      const d = e.data as { kind?: string; title?: string; body?: string } | null;
+      if (!d || d.kind !== "ss-voice-readback") return;
+      const text = [d.title, d.body].filter(Boolean).join(". ");
+      if (text) speakAlert(text);
+    };
+    navigator.serviceWorker.addEventListener("message", onMsg);
+    return () =>
+      navigator.serviceWorker.removeEventListener("message", onMsg);
   }, []);
   return null;
 }

--- a/lib/proximity-alert.ts
+++ b/lib/proximity-alert.ts
@@ -11,6 +11,7 @@
 
 import { haversineNm } from "./geo";
 import type { Aircraft, FleetRole } from "./types";
+import { speakAlert } from "./voice-mode";
 
 export const PROXIMITY_THRESHOLD_KEY = "ss_proximity_threshold_nm";
 export const PROXIMITY_ENABLED_KEY = "ss_proximity_enabled";
@@ -119,13 +120,18 @@ export async function fireProximityNotifications(
     const name = h.nickname ?? h.tail;
     const dist = h.distanceNm.toFixed(1);
     try {
-      await reg.showNotification(`${name} nearby`, {
-        body: `${dist} nm out. ${h.role === "smokey" ? "Watching." : "Eyes up."}`,
+      const title = `${name} nearby`;
+      const body = `${dist} nm out. ${h.role === "smokey" ? "Watching." : "Eyes up."}`;
+      await reg.showNotification(title, {
+        body,
         icon: "/icons/icon-192.png",
         badge: "/icons/favicon-96.png",
         tag: `proximity-${h.tail}`,
         data: { url: `/plane/${h.tail}`, tail: h.tail, kind: "proximity" },
       });
+      // Voice-mode readback (no-op when off / unsupported). Title + body
+      // separated by a period so the synth pauses naturally.
+      speakAlert(`${title}. ${body}`);
       markSeen(h.tail);
       posted += 1;
     } catch {

--- a/lib/voice-mode.ts
+++ b/lib/voice-mode.ts
@@ -1,0 +1,55 @@
+// Voice readback for push + proximity alerts. localStorage-backed,
+// mirrors the proximity-alert pattern. iOS Safari requires a
+// user-gesture before speechSynthesis.speak() works the first time —
+// the toggle's button click + the test-notification flow on
+// /settings/alerts both count, so the rider primes the API by opting
+// in.
+//
+// Limitation: speechSynthesis only fires when a page is open.
+// Background pushes with the tab fully closed will NOT speak. The
+// realistic helmet-audio use case keeps /radar or /dash visible while
+// riding, so this is acceptable for now.
+
+"use client";
+
+const ENABLED_KEY = "ss_voice_mode";
+
+export function isVoiceModeEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(ENABLED_KEY) === "1";
+}
+
+export function setVoiceModeEnabled(on: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(ENABLED_KEY, on ? "1" : "0");
+}
+
+export function isVoiceModeSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  return "speechSynthesis" in window;
+}
+
+/**
+ * Speak the given text via the platform speech synthesizer. No-op when
+ * voice mode is off, the API is unavailable, or text is empty. Cancels
+ * any in-flight utterance so back-to-back alerts don't queue forever.
+ *
+ * Brand voice: trust the caller to pass already-laconic copy. The push
+ * dispatcher's voice-guardian guarantees no exclamation marks and the
+ * mono-numerical phrasing — speak() does not transform.
+ */
+export function speakAlert(text: string): void {
+  if (!text) return;
+  if (!isVoiceModeEnabled()) return;
+  if (!isVoiceModeSupported()) return;
+  try {
+    window.speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.0;
+    u.pitch = 1.0;
+    u.volume = 1.0;
+    window.speechSynthesis.speak(u);
+  } catch {
+    // best-effort
+  }
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -22,7 +22,30 @@ self.addEventListener("push", (event) => {
     data: payload.data || {},
     silent: payload.silent === true,
   };
-  event.waitUntil(self.registration.showNotification(title, options));
+  event.waitUntil(
+    Promise.all([
+      self.registration.showNotification(title, options),
+      // Voice readback bridge — broadcast title/body to any open client
+      // so it can call speechSynthesis. SW itself can't speak. No-op
+      // when no tab is open; the page-side listener gates on the
+      // ss_voice_mode localStorage key.
+      clients
+        .matchAll({ type: "window", includeUncontrolled: true })
+        .then((wins) => {
+          for (const w of wins) {
+            try {
+              w.postMessage({
+                kind: "ss-voice-readback",
+                title,
+                body: options.body,
+              });
+            } catch (_) {
+              // best-effort
+            }
+          }
+        }),
+    ]),
+  );
 });
 
 self.addEventListener("notificationclick", (event) => {


### PR DESCRIPTION
## Summary
- New **Voice** section in `/settings/alerts` (between Proximity and Quiet Hours).
- Foreground proximity alerts speak via `speechSynthesis` when voice mode is on.
- Background push (tab open) speaks via SW → page postMessage bridge.
- iOS Safari user-gesture requirement satisfied by speaking "Voice readback on." on first opt-in.
- Brand voice already laconic + mono-numerical, no transformation.

## Limitation
Closed-tab background pushes do **not** speak — `speechSynthesis` requires an open page. Documented in copy and code comments. Realistic helmet-audio use case keeps `/radar` or `/dash` visible while riding.

## Test plan
- [ ] `/settings/alerts` shows Voice section with ENABLED checkbox
- [ ] Toggling persists in `localStorage` (`ss_voice_mode`)
- [ ] First opt-in speaks "Voice readback on." (primes iOS API)
- [ ] Foreground proximity alert speaks the body
- [ ] Browser-side push (tab open) speaks the body via SW message
- [ ] Closed tab does not speak (acknowledged limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)