### PR TITLE
feat(layout): /about tail registry → 2-column at desktop (Phase 2.4 contained slice)

### DIFF
--- a/app/(tabs)/about/page.tsx
+++ b/app/(tabs)/about/page.tsx
@@ -159,7 +159,7 @@ export default async function AboutPage() {
           public ADS-B sightings cross-referenced with state and county fleet
           records. Tap any tail to see its detail page.
         </p>
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div className="ss-grid-desktop-2">
           {fleet.map((f) => (
             <TailCard key={f.tail} entry={f} />
           ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,6 +177,23 @@ body {
   }
 }
 
+/* Multi-column grid for desktop sections that fan out well — currently
+   the /about tail registry. Mobile stays one column; ≥1280 px snaps to
+   two columns of equal width. Keep the gap aligned with the existing
+   18 px section gap. */
+.ss-grid-desktop-2 {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+@media (min-width: 1280px) {
+  .ss-grid-desktop-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+}
+
 /* Respect prefers-reduced-motion: kill the pulsers + transitions. */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## Status: open for your aesthetic review (NOT auto-merged)

## Summary
Targeted slice of P15 Phase 2.4 (multi-column desktop layouts). The plan called for restructuring `/`, `/activity`, and `/about` into multi-column desktop layouts, but those are aesthetic decisions:
- `/` Glanceable Hero is the brand focal point — 3-col split changes the silhouette
- `/activity` sidebar content needs a decision (fleet summary? metadata panel? what?)

This PR ships the contained, **low-aesthetic-risk** piece: the `/about` tail registry list now snaps to a 2-column CSS grid at ≥1280 px while staying single-column on mobile.

## What changed
- New utility class `.ss-grid-desktop-2` in globals.css
- `/about` tail registry uses it instead of `flex-direction: column`

## Deferred (your call)
- `/` Glanceable multi-column — comment your preference and I'll prep a focused PR
- `/activity` sidebar — same

## Test plan
- [ ] `/about` at mobile width: tail registry stays single column (no regression)
- [ ] `/about` at 1280 px+: tail registry shows in 2 columns of equal width
- [ ] Tail card hover/tap behavior unchanged
- [ ] Dark theme + brand voice unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)