### PR TITLE
feat(infra): NX7 federation namespace prep

### DIFF
--- a/lib/flights.ts
+++ b/lib/flights.ts
@@ -10,9 +10,10 @@ import {
 } from "./tracks";
 import { getRegistry } from "./registry";
 import { cacheGet, cacheSet } from "./cache";
+import { flightsRecentCacheKey } from "./storage-keys";
 import type { FleetEntry } from "./types";
 
-const CACHE_KEY = "flights:recent_cache_v1";
+const CACHE_KEY = flightsRecentCacheKey();
 const CACHE_TTL_SECONDS = 30;
 
 const LOOKBACK_DAYS = 7;

--- a/lib/hotzones.ts
+++ b/lib/hotzones.ts
@@ -13,6 +13,7 @@
 import { getRedis } from "./cache";
 import { getRegistry } from "./registry";
 import { listTrackKeys, getTracksForDay } from "./tracks";
+import { hotzonesCurrentKey, hotzonesLastRefreshKey } from "./storage-keys";
 
 // ~0.5 nm per cell at 47°N — roughly the granularity at which patrol
 // orbit patterns become visible without disappearing into the noise of
@@ -53,8 +54,8 @@ function inRegion(lat: number, lon: number): boolean {
   );
 }
 
-const CURRENT_KEY = "hotzones:current";
-const LAST_REFRESH_KEY = "hotzones:last_refresh_ts";
+const CURRENT_KEY = hotzonesCurrentKey();
+const LAST_REFRESH_KEY = hotzonesLastRefreshKey();
 const TTL_SECONDS = 25 * 60 * 60;
 
 /**

--- a/lib/per-plane-heatmap.ts
+++ b/lib/per-plane-heatmap.ts
@@ -11,11 +11,12 @@
 import { getRedis } from "./cache";
 import { listTrackKeys, getTracksForDay } from "./tracks";
 import { GRID_CELL_DEG, HOTZONE_DAYS_BACK, type HotZone } from "./hotzones";
+import { hotzonesPlaneKey } from "./storage-keys";
 
 const TTL_SECONDS = 6 * 60 * 60;
 
 function cacheKey(tail: string): string {
-  return `hotzones:plane:${tail.toUpperCase()}`;
+  return hotzonesPlaneKey(tail);
 }
 
 function utcDateKey(d: Date): string {

--- a/lib/spots.ts
+++ b/lib/spots.ts
@@ -3,6 +3,12 @@
 // listRecentSpots() (30s cache).
 
 import { getRedis, cacheGet, cacheSet } from "./cache";
+import {
+  SPOTS_PREFIX,
+  spotKey,
+  spotScanPattern,
+  spotsRecentCacheKey,
+} from "./storage-keys";
 
 export type SpotAirborneTail = {
   tail: string;
@@ -20,9 +26,8 @@ export type SpotPayload = {
 
 export type StoredSpot = SpotPayload & { id: string };
 
-const PREFIX = "spots:";
 const SPOT_TTL_SECONDS = 35 * 24 * 60 * 60;
-const RECENT_CACHE_KEY = "spots:recent_cache_v1";
+const RECENT_CACHE_KEY = spotsRecentCacheKey();
 const RECENT_CACHE_TTL = 30;
 
 function utcDateKey(d: Date): string {
@@ -42,7 +47,7 @@ export async function saveSpot(payload: SpotPayload): Promise<StoredSpot> {
       : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const stored: StoredSpot = { ...payload, id };
   const date = utcDateKey(new Date(payload.ts));
-  const key = `${PREFIX}${date}:${id}`;
+  const key = spotKey(date, id);
 
   await redis.set(key, JSON.stringify(stored), { ex: SPOT_TTL_SECONDS });
   // Bust the recent-cache so the admin page reflects the new spot
@@ -99,9 +104,9 @@ export async function listRecentSpots(limit = 100): Promise<StoredSpot[]> {
 
   // Scan only the date-prefixed keys we care about.
   const cutoff = utcDateKey(new Date(Date.now() - LOOKBACK_DAYS * 86_400_000));
-  const allKeys = await scanKeys(`${PREFIX}*`);
+  const allKeys = await scanKeys(spotScanPattern());
   const keys = allKeys.filter((k) => {
-    const date = k.slice(PREFIX.length).split(":")[0];
+    const date = k.slice(SPOTS_PREFIX.length).split(":")[0];
     return date != null && date >= cutoff;
   });
   if (keys.length === 0) {

--- a/lib/storage-keys.ts
+++ b/lib/storage-keys.ts
@@ -1,0 +1,67 @@
+// Centralized KV key formatter. NX7 federation foundation.
+//
+// Today every region-scoped namespace (tracks / spots / hotzones / flights)
+// uses an unprefixed key: e.g. tracks:N305DK:20260502. The default region
+// stays unprefixed to preserve byte-for-byte back-compat with all existing
+// data — no migration needed for Puget Sound. Non-default regions get a
+// region prefix slot: bay-area:tracks:N305DK:20260502.
+//
+// This module is the *only* place that should construct these keys going
+// forward. Direct string literals scattered across lib/* are how key drift
+// happens.
+//
+// Out of scope for the foundation:
+// - Per-region runtime selection (still hardcoded to default everywhere)
+// - Migrations (nothing to migrate; default == current shape)
+// - Per-region environment variables (single SS_REGION_* set today)
+//
+// Future Bay Area / etc. expansion is a config change (pick a Region, wire
+// it through the cron + handlers), not a data refactor.
+
+export type Region = string;
+export const DEFAULT_REGION: Region = "puget-sound";
+
+/** Empty for default region, "{region}:" otherwise. */
+function regionPrefix(region: Region | undefined): string {
+  if (!region || region === DEFAULT_REGION) return "";
+  return `${region}:`;
+}
+
+// ─── tracks:{tail}:{YYYYMMDD} ────────────────────────────────────────
+export function trackKey(tail: string, date: string, region?: Region): string {
+  return `${regionPrefix(region)}tracks:${tail}:${date}`;
+}
+export function trackScanPattern(tail: string, region?: Region): string {
+  return `${regionPrefix(region)}tracks:${tail}:*`;
+}
+export function trackScanAllPattern(region?: Region): string {
+  return `${regionPrefix(region)}tracks:*`;
+}
+
+// ─── spots:{YYYYMMDD}:{uuid} ─────────────────────────────────────────
+export const SPOTS_PREFIX = "spots:";
+export function spotKey(date: string, id: string, region?: Region): string {
+  return `${regionPrefix(region)}${SPOTS_PREFIX}${date}:${id}`;
+}
+export function spotScanPattern(region?: Region): string {
+  return `${regionPrefix(region)}${SPOTS_PREFIX}*`;
+}
+export function spotsRecentCacheKey(region?: Region): string {
+  return `${regionPrefix(region)}spots:recent_cache_v1`;
+}
+
+// ─── hotzones:* ──────────────────────────────────────────────────────
+export function hotzonesCurrentKey(region?: Region): string {
+  return `${regionPrefix(region)}hotzones:current`;
+}
+export function hotzonesLastRefreshKey(region?: Region): string {
+  return `${regionPrefix(region)}hotzones:last_refresh_ts`;
+}
+export function hotzonesPlaneKey(tail: string, region?: Region): string {
+  return `${regionPrefix(region)}hotzones:plane:${tail.toUpperCase()}`;
+}
+
+// ─── flights:* ───────────────────────────────────────────────────────
+export function flightsRecentCacheKey(region?: Region): string {
+  return `${regionPrefix(region)}flights:recent_cache_v1`;
+}

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -11,6 +11,7 @@
 import { getRedis } from "./cache";
 import { recordFirstSampleIfMissing } from "./learning";
 import { recordLastSample } from "./freshness";
+import { trackKey, trackScanPattern } from "./storage-keys";
 import type { Snapshot } from "./types";
 
 export type TrackPoint = {
@@ -58,7 +59,7 @@ export async function logTracks(snap: Snapshot): Promise<void> {
   await recordLastSample(snap.fetched_at);
 
   const writes = points.map(async (a) => {
-    const key = `tracks:${a.tail}:${date}`;
+    const key = trackKey(a.tail, date);
     const point: TrackPoint = {
       lat: a.lat as number,
       lon: a.lon as number,
@@ -86,7 +87,7 @@ export async function listTrackKeys(tail: string): Promise<string[]> {
   let cursor: string | number = 0;
   do {
     const result = (await redis.scan(cursor, {
-      match: `tracks:${tail}:*`,
+      match: trackScanPattern(tail),
       count: 100,
     })) as [string | number, string[]];
     for (const k of result[1]) {
@@ -105,7 +106,7 @@ export async function getTracksForDay(
 ): Promise<TrackPoint[]> {
   const redis = await getRedis();
   if (!redis) return [];
-  const key = `tracks:${tail}:${date}`;
+  const key = trackKey(tail, date);
   let raw: unknown[] = [];
   try {
     raw = (await redis.lrange(key, 0, -1)) as unknown[];
@@ -150,7 +151,7 @@ export async function getTrackSummary(tail: string): Promise<TrackSummary> {
   let total = 0;
   for (const date of dates) {
     try {
-      const len = (await redis.llen(`tracks:${tail}:${date}`)) as number;
+      const len = (await redis.llen(trackKey(tail, date))) as number;
       total += typeof len === "number" ? len : 0;
     } catch {
       /* skip */
@@ -159,8 +160,8 @@ export async function getTrackSummary(tail: string): Promise<TrackSummary> {
 
   const newest = dates[0]!;
   const oldest = dates[dates.length - 1]!;
-  const lastRaw = (await redis.lrange(`tracks:${tail}:${newest}`, -1, -1)) as unknown[];
-  const firstRaw = (await redis.lrange(`tracks:${tail}:${oldest}`, 0, 0)) as unknown[];
+  const lastRaw = (await redis.lrange(trackKey(tail, newest), -1, -1)) as unknown[];
+  const firstRaw = (await redis.lrange(trackKey(tail, oldest), 0, 0)) as unknown[];
   const last = safeParse(lastRaw[0]);
   const first = safeParse(firstRaw[0]);
 


### PR DESCRIPTION
## Summary
Foundation for future regional expansion. All region-scoped KV keys (`tracks:*`, `spots:*`, `hotzones:*`, `flights:*`) now route through the new `lib/storage-keys.ts` module.

## Back-compat
For `DEFAULT_REGION = 'puget-sound'`, the formatter returns **byte-for-byte identical** key shapes to the prior literals. Zero migration needed — existing data is fully readable + writable.

## What changed
- New `lib/storage-keys.ts` exports `trackKey`, `spotKey`, `hotzonesCurrentKey`, etc.
- All consumer libs (tracks, spots, hotzones, per-plane-heatmap, flights) updated to call the formatter
- `scripts/backfill*.ts` kept on direct literals (operator tools, not runtime)

## Out of scope (deliberate)
- Per-region runtime selection (still hardcoded to default)
- Migrations (nothing to migrate)
- Per-region env vars

## Test plan
- [ ] Existing prod KV reads still work (admin tracks, /radar heatmap, flights)
- [ ] Cron writes (`/api/cron/refresh-snapshot`, `/api/cron/refresh-hotzones`) write to expected keys
- [ ] Per-plane heatmap on `/plane/[tail]` still loads
- [ ] Spots on `/admin/spots` still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)