### PR TITLE
feat(n1a): speed-warning DRY-RUN logging

### DIFF
--- a/app/admin/dryrun-warnings/page.tsx
+++ b/app/admin/dryrun-warnings/page.tsx
@@ -1,0 +1,231 @@
+// Admin viewer for the speed-warning DRY-RUN log (N1a). Reads the
+// dryrun-warnings:{YYYYMMDD} list for the current UTC day and renders
+// a compact table. Used to tune the trigger threshold before shipping
+// any rider-facing warning surface (N1b).
+
+import { getRedis } from "@/lib/cache";
+import { isAdminAuthed, isAdminPasscodeConfigured } from "@/lib/admin-auth";
+import { LoginForm } from "../LoginForm";
+import { SS_TOKENS } from "@/lib/tokens";
+
+export const dynamic = "force-dynamic";
+export const metadata = {
+  title: "SmokySignal · Admin · Dry-run warnings",
+  robots: { index: false, follow: false },
+};
+
+type DryRunRecord = {
+  ts: number;
+  riderLat: number;
+  riderLon: number;
+  riderSpeedMph: number;
+  postedLimitMph: number;
+  riderOverLimitBy: number;
+  nearestZoneMi: number | null;
+  nearestBirdMi: number | null;
+  nearestTail: string | null;
+  reason: string;
+};
+
+function utcDateKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+function parse(raw: unknown): DryRunRecord | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as DryRunRecord;
+    } catch {
+      return null;
+    }
+  }
+  return raw as DryRunRecord;
+}
+
+async function fetchToday(): Promise<DryRunRecord[]> {
+  const redis = await getRedis();
+  if (!redis) return [];
+  const key = `dryrun-warnings:${utcDateKey(new Date())}`;
+  try {
+    const raw = (await redis.lrange(key, 0, -1)) as unknown[];
+    return raw.map(parse).filter((r): r is DryRunRecord => r !== null);
+  } catch {
+    return [];
+  }
+}
+
+export default async function DryRunPage() {
+  if (!isAdminPasscodeConfigured()) {
+    return <Missing />;
+  }
+  if (!isAdminAuthed()) {
+    return <LoginForm next="/admin/dryrun-warnings" />;
+  }
+
+  const records = await fetchToday();
+  return (
+    <main
+      style={{
+        maxWidth: 960,
+        margin: "0 auto",
+        padding: "24px 18px 80px",
+      }}
+    >
+      <header style={{ marginBottom: 18 }}>
+        <div className="ss-eyebrow" style={{ marginBottom: 6 }}>
+          Admin · N1a dry-run
+        </div>
+        <h1
+          className="ss-mono"
+          style={{
+            fontSize: 18,
+            color: SS_TOKENS.fg0,
+            letterSpacing: ".04em",
+            margin: 0,
+          }}
+        >
+          Speed-warning candidates · today (UTC)
+        </h1>
+        <p style={{ color: SS_TOKENS.fg1, fontSize: 13, marginTop: 8 }}>
+          Logged when a rider was over the limit, in a hot zone, and a
+          tracked bird was within 5 nm. No rider-facing surface yet —
+          this is the data we&rsquo;ll tune the threshold against.
+        </p>
+      </header>
+
+      {records.length === 0 ? (
+        <div
+          style={{
+            padding: "40px 18px",
+            background: SS_TOKENS.bg1,
+            border: `.5px solid ${SS_TOKENS.hairline}`,
+            borderRadius: 12,
+            textAlign: "center",
+            color: SS_TOKENS.fg2,
+            fontSize: 13,
+          }}
+        >
+          No dry-run candidates today yet.
+        </div>
+      ) : (
+        <Table records={records} />
+      )}
+    </main>
+  );
+}
+
+function Table({ records }: { records: DryRunRecord[] }) {
+  return (
+    <div
+      style={{
+        background: SS_TOKENS.bg1,
+        border: `.5px solid ${SS_TOKENS.hairline}`,
+        borderRadius: 12,
+        overflow: "hidden",
+      }}
+    >
+      <table
+        className="ss-mono"
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: 12,
+          color: SS_TOKENS.fg1,
+        }}
+      >
+        <thead style={{ background: SS_TOKENS.bg2 }}>
+          <tr>
+            <Th>UTC time</Th>
+            <Th align="right">Speed</Th>
+            <Th align="right">Limit</Th>
+            <Th align="right">Over by</Th>
+            <Th align="right">Zone nm</Th>
+            <Th align="right">Bird nm</Th>
+            <Th>Tail</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {records
+            .slice()
+            .reverse()
+            .map((r, i) => (
+              <tr
+                key={i}
+                style={{ borderTop: `.5px solid ${SS_TOKENS.hairline}` }}
+              >
+                <Td>
+                  {new Date(r.ts)
+                    .toISOString()
+                    .slice(11, 19)}
+                </Td>
+                <Td align="right">{r.riderSpeedMph.toFixed(0)}</Td>
+                <Td align="right">{r.postedLimitMph.toFixed(0)}</Td>
+                <Td align="right">{r.riderOverLimitBy.toFixed(0)}</Td>
+                <Td align="right">
+                  {r.nearestZoneMi == null ? "—" : r.nearestZoneMi.toFixed(2)}
+                </Td>
+                <Td align="right">
+                  {r.nearestBirdMi == null ? "—" : r.nearestBirdMi.toFixed(2)}
+                </Td>
+                <Td>{r.nearestTail ?? "—"}</Td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Th({
+  children,
+  align,
+}: {
+  children: React.ReactNode;
+  align?: "right";
+}) {
+  return (
+    <th
+      style={{
+        padding: "10px 12px",
+        textAlign: align ?? "left",
+        color: SS_TOKENS.fg2,
+        fontWeight: 600,
+        letterSpacing: ".04em",
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  align,
+}: {
+  children: React.ReactNode;
+  align?: "right";
+}) {
+  return (
+    <td
+      style={{
+        padding: "8px 12px",
+        textAlign: align ?? "left",
+        color: SS_TOKENS.fg0,
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function Missing() {
+  return (
+    <div style={{ padding: 24, color: SS_TOKENS.fg1 }}>
+      ADMIN_PASSCODE not set in this environment.
+    </div>
+  );
+}

--- a/app/api/dryrun-warnings/route.ts
+++ b/app/api/dryrun-warnings/route.ts
@@ -1,0 +1,116 @@
+// N1a: collect speed-warning DRY-RUN candidates from real rider sessions.
+// No UI yet — this just logs evaluateWarning() positives so we can tune
+// the threshold before showing anything to riders.
+//
+// Storage: dryrun-warnings:{YYYYMMDD} as a Redis list, 7-day TTL.
+// Each entry is a compact JSON record. Keep payloads small — riders log
+// continuously while the dash is open.
+
+import { NextResponse } from "next/server";
+import { getRedis } from "@/lib/cache";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const TTL_SECONDS = 7 * 24 * 60 * 60;
+const NOW_TOLERANCE_MS = 5 * 60 * 1000;
+
+function isFiniteNum(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n);
+}
+
+function utcDateKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}${m}${day}`;
+}
+
+type DryRunRecord = {
+  ts: number;
+  riderLat: number;
+  riderLon: number;
+  riderSpeedMph: number;
+  postedLimitMph: number;
+  riderOverLimitBy: number;
+  nearestZoneMi: number | null;
+  nearestBirdMi: number | null;
+  nearestTail: string | null;
+  reason: string;
+};
+
+function parseBody(raw: unknown): DryRunRecord | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    !isFiniteNum(r.ts) ||
+    !isFiniteNum(r.riderLat) ||
+    !isFiniteNum(r.riderLon) ||
+    !isFiniteNum(r.riderSpeedMph) ||
+    !isFiniteNum(r.postedLimitMph) ||
+    !isFiniteNum(r.riderOverLimitBy)
+  ) {
+    return null;
+  }
+  if (Math.abs(Date.now() - r.ts) > NOW_TOLERANCE_MS) return null;
+  if (r.riderLat < -90 || r.riderLat > 90) return null;
+  if (r.riderLon < -180 || r.riderLon > 180) return null;
+  return {
+    ts: r.ts,
+    riderLat: r.riderLat,
+    riderLon: r.riderLon,
+    riderSpeedMph: r.riderSpeedMph,
+    postedLimitMph: r.postedLimitMph,
+    riderOverLimitBy: r.riderOverLimitBy,
+    nearestZoneMi:
+      r.nearestZoneMi == null
+        ? null
+        : isFiniteNum(r.nearestZoneMi)
+          ? r.nearestZoneMi
+          : null,
+    nearestBirdMi:
+      r.nearestBirdMi == null
+        ? null
+        : isFiniteNum(r.nearestBirdMi)
+          ? r.nearestBirdMi
+          : null,
+    nearestTail:
+      typeof r.nearestTail === "string" ? r.nearestTail.toUpperCase() : null,
+    reason: typeof r.reason === "string" ? r.reason.slice(0, 200) : "",
+  };
+}
+
+export async function POST(req: Request) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "bad json" }, { status: 400 });
+  }
+  const rec = parseBody(raw);
+  if (!rec) {
+    return NextResponse.json({ ok: false, error: "invalid" }, { status: 400 });
+  }
+
+  const redis = await getRedis();
+  if (!redis) {
+    // KV not configured (dev) — accept and drop.
+    return NextResponse.json({ ok: true, dropped: true });
+  }
+  const key = `dryrun-warnings:${utcDateKey(new Date(rec.ts))}`;
+  try {
+    await redis.rpush(key, JSON.stringify(rec));
+    await redis.expire(key, TTL_SECONDS);
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, error: "store failed" },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  // Health probe used by verify-prod.
+  return NextResponse.json({ ok: true, endpoint: "dryrun-warnings" });
+}

--- a/components/DashShell.tsx
+++ b/components/DashShell.tsx
@@ -6,7 +6,9 @@ import { useAircraft } from "@/lib/hooks/useAircraft";
 import { useRiderPos } from "@/lib/hooks/useRiderPos";
 import { SS_TOKENS } from "@/lib/tokens";
 import { SMOKY_TAIL } from "@/lib/seed";
-import { haversineNm } from "@/lib/geo";
+import { DEFAULT_SPEED_LIMIT_MPH, haversineNm } from "@/lib/geo";
+import { evaluateWarning } from "@/lib/speed-warning";
+import type { HotZone } from "@/lib/hotzones";
 import { StatusPill } from "./StatusPill";
 import { Card } from "./Card";
 import { AlertsOptInCard } from "./AlertsOptInCard";
@@ -57,6 +59,65 @@ export function DashShell({ initial, initialActivity, mockOn = false }: Props) {
     return ranked.slice(0, NEAREST_LIST_LIMIT);
   }, [pos, airborne]);
   const nearest = nearestList[0] ?? null;
+
+  // N1a dry-run logging: fetch hot zones once on mount, then on each
+  // rider geolocation tick + airborne refresh, evaluate the warning
+  // condition and POST positives to /api/dryrun-warnings. No UI surface
+  // — that's N1b, gated on this data accumulating.
+  const [hotZones, setHotZones] = useState<HotZone[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/hotzones")
+      .then((r) => (r.ok ? r.json() : { zones: [] }))
+      .then((data) => {
+        if (cancelled) return;
+        const zones = Array.isArray(data?.zones) ? data.zones : [];
+        setHotZones(zones as HotZone[]);
+      })
+      .catch(() => {
+        // best-effort; absent zones just means evaluateWarning returns
+        // wouldFire=false (no zone match)
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  // m/s → mph
+  const MPS_TO_MPH = 2.236936;
+  useEffect(() => {
+    if (!pos) return;
+    if (pos.speedMps == null || pos.speedMps < 0) return;
+    if (hotZones.length === 0 && airborne.length === 0) return;
+    const result = evaluateWarning({
+      riderLat: pos.lat,
+      riderLon: pos.lon,
+      riderSpeedMph: pos.speedMps * MPS_TO_MPH,
+      postedLimitMph: DEFAULT_SPEED_LIMIT_MPH,
+      hotZones,
+      airborneAircraft: airborne,
+    });
+    if (!result.wouldFire) return;
+    const nearestTail = nearestList[0]?.plane.tail ?? null;
+    console.log("[dryrun]", result.reason);
+    void fetch("/api/dryrun-warnings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ts: Date.now(),
+        riderLat: pos.lat,
+        riderLon: pos.lon,
+        riderSpeedMph: pos.speedMps * MPS_TO_MPH,
+        postedLimitMph: DEFAULT_SPEED_LIMIT_MPH,
+        riderOverLimitBy: result.riderOverLimitBy,
+        nearestZoneMi: result.nearestZoneMi,
+        nearestBirdMi: result.nearestBirdMi,
+        nearestTail,
+        reason: result.reason,
+      }),
+    }).catch(() => {
+      // best-effort; transient network errors don't matter for dry-run
+    });
+  }, [pos, hotZones, airborne, nearestList]);
 
   // Poll /api/activity every 10s.
   useEffect(() => {

--- a/lib/speed-warning.ts
+++ b/lib/speed-warning.ts
@@ -1,0 +1,109 @@
+// Speed-warning evaluation. Pure function, no side effects. Used by:
+//   - DashShell to log dry-run candidates to /api/dryrun-warnings
+//   - (future N1b) the rider-facing warning surface
+//
+// Trigger condition (all must hold):
+//   1. Rider speed > posted limit (with a small tolerance to absorb GPS jitter)
+//   2. Rider is inside an active hot zone (zone center within riderZoneRadiusNm)
+//   3. A tracked alert-tier (smokey | patrol | unknown) plane is airborne
+//      within `birdThresholdNm` nautical miles of the rider
+//
+// All three are required because any one alone is too noisy:
+//   - Speeding alone fires constantly on freeways
+//   - In-a-hot-zone alone is the same as the existing zone alerts
+//   - Bird-nearby alone is the existing proximity alert (P14)
+//
+// The combination — over-the-limit, where Smokey patrols, with Smokey overhead —
+// is the actual "you're about to get a ticket" signal worth surfacing.
+
+import { haversineNm } from "./geo";
+import type { Aircraft, FleetRole } from "./types";
+import type { HotZone } from "./hotzones";
+
+// km per nautical mile (for the zone-radius check). 1 nm ≈ 1.852 km.
+const ALERT_ROLES: ReadonlySet<FleetRole> = new Set([
+  "smokey",
+  "patrol",
+  "unknown",
+]);
+
+// GPS speed jitters by ~2 mph at highway speeds. Don't fire on +1.
+const SPEED_TOLERANCE_MPH = 2;
+
+export type SpeedWarningInput = {
+  riderLat: number;
+  riderLon: number;
+  riderSpeedMph: number;
+  postedLimitMph: number;
+  /** Center of recent fleet activity (lib/hotzones.ts). Only lat/lon used. */
+  hotZones: Pick<HotZone, "lat" | "lon">[];
+  /** Live snapshot of airborne aircraft (lib/snapshot.ts). */
+  airborneAircraft: Aircraft[];
+  /** Distance threshold for "bird nearby." Default 5nm. */
+  birdThresholdNm?: number;
+  /** Distance threshold for "in a hot zone." Default 0.5nm. */
+  riderZoneRadiusNm?: number;
+};
+
+export type SpeedWarningResult = {
+  /** All three conditions met. */
+  wouldFire: boolean;
+  /** Human-readable reason for the result (warning text or non-fire cause). */
+  reason: string;
+  /** Rider speed minus posted limit. Negative if under. */
+  riderOverLimitBy: number;
+  /** Distance to nearest hot-zone center, or null when no zones at all. */
+  nearestZoneMi: number | null;
+  /** Distance to nearest alert-tier airborne plane, or null when none up. */
+  nearestBirdMi: number | null;
+};
+
+export function evaluateWarning(
+  input: SpeedWarningInput,
+): SpeedWarningResult {
+  const birdThreshold = input.birdThresholdNm ?? 5;
+  const riderZoneRadius = input.riderZoneRadiusNm ?? 0.5;
+  const overLimit = input.riderSpeedMph - input.postedLimitMph;
+
+  let nearestZoneMi: number | null = null;
+  for (const z of input.hotZones) {
+    const d = haversineNm(input.riderLat, input.riderLon, z.lat, z.lon);
+    if (nearestZoneMi == null || d < nearestZoneMi) nearestZoneMi = d;
+  }
+
+  let nearestBirdMi: number | null = null;
+  for (const a of input.airborneAircraft) {
+    if (!a.airborne) continue;
+    if (a.lat == null || a.lon == null) continue;
+    if (!ALERT_ROLES.has(a.role)) continue;
+    const d = haversineNm(input.riderLat, input.riderLon, a.lat, a.lon);
+    if (nearestBirdMi == null || d < nearestBirdMi) nearestBirdMi = d;
+  }
+
+  const speeding = overLimit > SPEED_TOLERANCE_MPH;
+  const inZone = nearestZoneMi != null && nearestZoneMi <= riderZoneRadius;
+  const birdNearby = nearestBirdMi != null && nearestBirdMi <= birdThreshold;
+
+  if (speeding && inZone && birdNearby) {
+    return {
+      wouldFire: true,
+      reason: `Over by ${overLimit.toFixed(0)} mph in a hot zone, bird ${nearestBirdMi!.toFixed(1)} nm out`,
+      riderOverLimitBy: overLimit,
+      nearestZoneMi,
+      nearestBirdMi,
+    };
+  }
+
+  // Build a non-firing reason explaining what's missing.
+  const missing: string[] = [];
+  if (!speeding) missing.push("under limit");
+  if (!inZone) missing.push("not in zone");
+  if (!birdNearby) missing.push("no bird nearby");
+  return {
+    wouldFire: false,
+    reason: missing.join(", "),
+    riderOverLimitBy: overLimit,
+    nearestZoneMi,
+    nearestBirdMi,
+  };
+}


### PR DESCRIPTION
## Summary
N1a foundation. No rider-facing change — pure data collection so we can pick the right speed-warning trigger threshold from real sessions before shipping the N1b rider surface.

## Trigger condition (all three required)
1. Rider over the limit by > 2 mph (GPS jitter tolerance)
2. Rider inside an active hot zone (≤ 0.5 nm from cell center)
3. Tracked alert-tier plane airborne ≤ 5 nm

## What changed
- `lib/speed-warning.ts` — pure `evaluateWarning(input)` function
- `app/api/dryrun-warnings/route.ts` — POST collects, GET is verify-prod health probe
- `app/admin/dryrun-warnings/page.tsx` — admin viewer, mono table
- `components/DashShell.tsx` — fetches hot zones, runs evaluator on every tick, POSTs positives

## Storage
`dryrun-warnings:{YYYYMMDD}` Redis list, 7-day TTL.

## N1b (deferred)
Rider-facing UI gated on 5–7 days of data accumulation.

## Test plan
- [ ] `GET /api/dryrun-warnings` returns 200 `{ok:true,endpoint:"dryrun-warnings"}`
- [ ] `POST /api/dryrun-warnings` with valid body returns 200; invalid body returns 400
- [ ] `/admin/dryrun-warnings` (after admin login) renders the empty-state card
- [ ] DashShell logs `[dryrun]` to console when conditions met (testable in dev with mocked rider pos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)