### PR TITLE
feat(radar): FilterPanel extraction + multi-select Roles

### DIFF
--- a/components/FilterPanel.tsx
+++ b/components/FilterPanel.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+// Radar filter panel — extracted from HotZoneLayer.tsx in P16 Phase 3.
+// Lives in its own file so other surfaces (future weather toggle,
+// time-scrubber settings) can mount alongside the existing radar
+// filters without bloating the heatmap layer module.
+//
+// Filter shape: see lib/radar-filter.ts. Multi-select roles are new in
+// P16 — empty array means "show all roles" (back-compat with prior
+// persisted filter state).
+
+import { SS_TOKENS } from "@/lib/tokens";
+import {
+  FILTERABLE_ROLES,
+  OPERATORS,
+  type FilterableRole,
+  type RadarFilter as Filter,
+} from "@/lib/radar-filter";
+
+type Props = {
+  bottom: number;
+  filter: Filter;
+  onChange: (f: Filter) => void;
+  onClose: () => void;
+};
+
+export function FilterPanel({ bottom, filter, onChange, onClose }: Props) {
+  const toggleRole = (role: FilterableRole) => {
+    const set = new Set(filter.roles);
+    if (set.has(role)) set.delete(role);
+    else set.add(role);
+    onChange({
+      ...filter,
+      roles: [...set] as FilterableRole[],
+    });
+  };
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 12,
+        bottom,
+        zIndex: 13,
+        width: 240,
+        padding: "12px 14px",
+        borderRadius: 14,
+        background: "rgba(11,13,16,0.92)",
+        border: `.5px solid ${SS_TOKENS.hairline2}`,
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        color: SS_TOKENS.fg0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <span
+          className="ss-mono"
+          style={{ fontSize: 11, color: SS_TOKENS.fg2, letterSpacing: ".1em" }}
+        >
+          HOT ZONES
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close filter panel"
+          style={{
+            background: "transparent",
+            border: 0,
+            color: SS_TOKENS.fg2,
+            cursor: "pointer",
+            fontSize: 16,
+            lineHeight: 1,
+            padding: 0,
+            touchAction: "manipulation",
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <Group label="Show">
+        <Pill
+          active={filter.showMode === "all"}
+          onClick={() => onChange({ ...filter, showMode: "all" })}
+        >
+          All
+        </Pill>
+        <Pill
+          active={filter.showMode === "smoky"}
+          onClick={() => onChange({ ...filter, showMode: "smoky" })}
+        >
+          Smokey
+        </Pill>
+        <Pill
+          active={filter.showMode === "operator"}
+          onClick={() => onChange({ ...filter, showMode: "operator" })}
+        >
+          Operator
+        </Pill>
+      </Group>
+
+      {filter.showMode === "operator" && (
+        <select
+          value={filter.operator ?? "WSP"}
+          onChange={(e) => onChange({ ...filter, operator: e.target.value })}
+          className="ss-mono"
+          style={{
+            background: SS_TOKENS.bg2,
+            border: `.5px solid ${SS_TOKENS.hairline2}`,
+            color: SS_TOKENS.fg0,
+            fontSize: 12,
+            padding: "6px 8px",
+            borderRadius: 8,
+          }}
+        >
+          {OPERATORS.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <Group label="Roles">
+        {FILTERABLE_ROLES.map((role) => (
+          <Pill
+            key={role}
+            active={filter.roles.includes(role)}
+            onClick={() => toggleRole(role)}
+          >
+            {role.toUpperCase()}
+          </Pill>
+        ))}
+      </Group>
+
+      <Group label="Region">
+        <Pill
+          active={filter.region === "puget_sound"}
+          onClick={() => onChange({ ...filter, region: "puget_sound" })}
+        >
+          Puget Sound
+        </Pill>
+        <Pill
+          active={filter.region === "all"}
+          onClick={() => onChange({ ...filter, region: "all" })}
+        >
+          Statewide
+        </Pill>
+      </Group>
+    </div>
+  );
+}
+
+function Group({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <span
+        className="ss-mono"
+        style={{ fontSize: 9.5, color: SS_TOKENS.fg2, letterSpacing: ".1em" }}
+      >
+        {label}
+      </span>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>{children}</div>
+    </div>
+  );
+}
+
+function Pill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className="ss-mono"
+      style={{
+        padding: "5px 10px",
+        borderRadius: 999,
+        background: active ? SS_TOKENS.alert : "transparent",
+        border: `.5px solid ${active ? SS_TOKENS.alert : SS_TOKENS.hairline2}`,
+        color: active ? SS_TOKENS.bg0 : SS_TOKENS.fg1,
+        fontSize: 10.5,
+        letterSpacing: ".04em",
+        cursor: "pointer",
+        touchAction: "manipulation",
+        WebkitTapHighlightColor: "transparent",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/HotZoneLayer.tsx
+++ b/components/HotZoneLayer.tsx
@@ -16,7 +16,6 @@ import type { HotZone } from "@/lib/hotzones";
 import type { LearningState } from "@/lib/learning";
 import {
   DEFAULT_RADAR_FILTER,
-  OPERATORS,
   RADAR_FILTER_CHANGE_EVENT,
   SMOKY_FILTER_ROLES,
   readRadarFilter,
@@ -27,6 +26,7 @@ import { REGION_CHANGE_EVENT, getRegion } from "@/lib/region-pref";
 import type { RegionId } from "@/lib/regions";
 import { Tooltip } from "./Tooltip";
 import { LearningPanel } from "./LearningPanel";
+import { FilterPanel } from "./FilterPanel";
 
 const VISIBLE_KEY = "ss_hotzones_visible";
 const SOURCE_ID = "hotzones";
@@ -50,6 +50,10 @@ function buildQueryString(f: Filter, regionId: RegionId): string {
   // filter without a config change.
   if (f.showMode === "smoky") p.set("roles", SMOKY_FILTER_ROLES.join(","));
   if (f.showMode === "operator" && f.operator) p.set("operator", f.operator);
+  // Multi-select role allow-list overrides the legacy showMode role
+  // shortcut when present. Server-side /api/hotzones already accepts
+  // a comma-separated `roles` value.
+  if (f.roles.length > 0) p.set("roles", f.roles.join(","));
   return p.toString();
 }
 
@@ -453,191 +457,6 @@ function pillStyle(color: string): React.CSSProperties {
     touchAction: "manipulation",
     WebkitTapHighlightColor: "transparent",
   };
-}
-
-function FilterPanel({
-  bottom,
-  filter,
-  onChange,
-  onClose,
-}: {
-  bottom: number;
-  filter: Filter;
-  onChange: (f: Filter) => void;
-  onClose: () => void;
-}) {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        left: 12,
-        bottom,
-        zIndex: 13,
-        width: 240,
-        padding: "12px 14px",
-        borderRadius: 14,
-        background: "rgba(11,13,16,0.92)",
-        border: `.5px solid ${SS_TOKENS.hairline2}`,
-        backdropFilter: "blur(10px)",
-        WebkitBackdropFilter: "blur(10px)",
-        color: SS_TOKENS.fg0,
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <span
-          className="ss-mono"
-          style={{
-            fontSize: 11,
-            color: SS_TOKENS.fg2,
-            letterSpacing: ".1em",
-          }}
-        >
-          HOT ZONES
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close filter panel"
-          style={{
-            background: "transparent",
-            border: 0,
-            color: SS_TOKENS.fg2,
-            cursor: "pointer",
-            fontSize: 16,
-            lineHeight: 1,
-            padding: 0,
-            touchAction: "manipulation",
-          }}
-        >
-          ×
-        </button>
-      </div>
-
-      <Group label="Show">
-        <Pill
-          active={filter.showMode === "all"}
-          onClick={() => onChange({ ...filter, showMode: "all" })}
-        >
-          All
-        </Pill>
-        <Pill
-          active={filter.showMode === "smoky"}
-          onClick={() => onChange({ ...filter, showMode: "smoky" })}
-        >
-          Smokey
-        </Pill>
-        <Pill
-          active={filter.showMode === "operator"}
-          onClick={() => onChange({ ...filter, showMode: "operator" })}
-        >
-          Operator
-        </Pill>
-      </Group>
-
-      {filter.showMode === "operator" && (
-        <select
-          value={filter.operator ?? "WSP"}
-          onChange={(e) => onChange({ ...filter, operator: e.target.value })}
-          className="ss-mono"
-          style={{
-            background: SS_TOKENS.bg2,
-            border: `.5px solid ${SS_TOKENS.hairline2}`,
-            color: SS_TOKENS.fg0,
-            fontSize: 12,
-            padding: "6px 8px",
-            borderRadius: 8,
-          }}
-        >
-          {OPERATORS.map((o) => (
-            <option key={o} value={o}>
-              {o}
-            </option>
-          ))}
-        </select>
-      )}
-
-      <Group label="Region">
-        <Pill
-          active={filter.region === "puget_sound"}
-          onClick={() => onChange({ ...filter, region: "puget_sound" })}
-        >
-          Puget Sound
-        </Pill>
-        <Pill
-          active={filter.region === "all"}
-          onClick={() => onChange({ ...filter, region: "all" })}
-        >
-          Statewide
-        </Pill>
-      </Group>
-    </div>
-  );
-}
-
-function Group({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-      <span
-        className="ss-mono"
-        style={{
-          fontSize: 9.5,
-          color: SS_TOKENS.fg2,
-          letterSpacing: ".1em",
-        }}
-      >
-        {label}
-      </span>
-      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>{children}</div>
-    </div>
-  );
-}
-
-function Pill({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className="ss-mono"
-      style={{
-        padding: "5px 10px",
-        borderRadius: 999,
-        background: active ? SS_TOKENS.alert : "transparent",
-        border: `.5px solid ${active ? SS_TOKENS.alert : SS_TOKENS.hairline2}`,
-        color: active ? SS_TOKENS.bg0 : SS_TOKENS.fg1,
-        fontSize: 10.5,
-        letterSpacing: ".04em",
-        cursor: "pointer",
-        touchAction: "manipulation",
-        WebkitTapHighlightColor: "transparent",
-      }}
-    >
-      {children}
-    </button>
-  );
 }
 
 function toFeatureCollection(

--- a/lib/radar-filter.ts
+++ b/lib/radar-filter.ts
@@ -12,10 +12,22 @@
 export type RadarFilterShowMode = "all" | "smoky" | "operator";
 export type RadarFilterRegion = "puget_sound" | "all";
 
+/** Role IDs the rider can multi-select. Mirrors lib/types.ts FleetRole. */
+export const FILTERABLE_ROLES = [
+  "smokey",
+  "patrol",
+  "sar",
+  "transport",
+  "unknown",
+] as const;
+export type FilterableRole = (typeof FILTERABLE_ROLES)[number];
+
 export type RadarFilter = {
   showMode: RadarFilterShowMode;
   operator: string | null;
   region: RadarFilterRegion;
+  /** Multi-select role allow-list. Empty = show all roles. */
+  roles: FilterableRole[];
 };
 
 export const RADAR_FILTER_KEY = "ss_hotzones_filter";
@@ -49,6 +61,7 @@ export const DEFAULT_RADAR_FILTER: RadarFilter = {
   showMode: "all",
   operator: "WSP",
   region: "puget_sound",
+  roles: [],
 };
 
 export function readRadarFilter(): RadarFilter {
@@ -68,6 +81,13 @@ export function readRadarFilter(): RadarFilter {
           ? parsed.operator
           : "WSP",
       region: parsed.region === "all" ? "all" : "puget_sound",
+      // roles is new in this shape; missing on prior persisted state →
+      // empty array (which means "show all", same behavior as before).
+      roles: Array.isArray(parsed.roles)
+        ? (parsed.roles.filter((r) =>
+            (FILTERABLE_ROLES as readonly string[]).includes(r as string),
+          ) as FilterableRole[])
+        : [],
     };
   } catch {
     return DEFAULT_RADAR_FILTER;
@@ -90,6 +110,17 @@ export function passesAircraftFilter(
   aircraft: { tail: string; operator: string; role?: string },
   f: RadarFilter,
 ): boolean {
+  // Multi-select role filter (new). Empty array = no role constraint.
+  if (f.roles.length > 0) {
+    if (
+      typeof aircraft.role !== "string" ||
+      !(f.roles as readonly string[]).includes(aircraft.role)
+    ) {
+      return false;
+    }
+  }
+  // Existing showMode predicate runs after roles. The two compose:
+  // role ∈ allow-list AND showMode passes.
   if (f.showMode === "all") return true;
   if (f.showMode === "smoky") {
     return (


### PR DESCRIPTION
## Summary
P16 Phase 3. Aligns with reality after P15's recon found the FilterPanel was inline in `HotZoneLayer.tsx` and the filter shape was `{showMode, operator, region}` (NOT `{operator, tail}` from the prior plan).

## What changed
- **New `components/FilterPanel.tsx`** — inline FilterPanel + Group + Pill helpers extracted, then extended with a Roles section.
- **New filter field**: `roles: FilterableRole[]` (smokey | patrol | sar | transport | unknown). Empty = no role constraint (back-compat).
- Filters compose: `passesAircraftFilter()` applies roles allow-list AND existing showMode predicate.
- `buildQueryString()` forwards roles to `/api/hotzones` (server already accepts).
- `readRadarFilter()` migration: missing `roles[]` → `[]`. Same persisted key, no localStorage migration needed.
- `HotZoneLayer.tsx` slimmed by ~190 lines (now 474 down from 654).

## Out of scope (deferred)
- `operators[]` multi-select — current single-operator under `showMode='operator'` is sufficient for the verify-prod assertion
- Weather/Layers toggle — that's Phase 4 (NX2)

## Test plan
- [ ] `/radar` filter chevron opens the panel; Roles section shows 5 pills (SMOKEY, PATROL, SAR, TRANSPORT, UNKNOWN)
- [ ] Toggling a role pill visibly removes/restores those aircraft markers
- [ ] Toggling a role pill changes the heatmap (server filter)
- [ ] Persistence survives reload (localStorage `ss_hotzones_filter`)
- [ ] Existing showMode behavior (All / Smokey / Operator) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)