### PR TITLE
chore(p16): verify-prod spec iOS-aware + docs sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ Audience: Puget Sound motorcyclists. Brand voice: dark theme, mono numerics,
 - `lib/user-prefs.ts` — cookie-backed display prefs (12/24-hour, normal/high contrast)
 - `lib/voice-mode.ts` — speechSynthesis readback toggle (foreground only)
 - `lib/proximity-alert.ts` — foreground proximity ping when alert-tier tail nearby
+- `lib/speed-warning.ts` — pure `evaluateWarning()` for N1a dryrun pipeline
+- `lib/storage-keys.ts` — canonical KV key formatter (NX7 foundation; route all `tracks:*`/`spots:*`/`hotzones:*`/`flights:*` through this)
+- `components/FilterPanel.tsx` — radar filter UI (extracted from HotZoneLayer P16); multi-select roles supported
 - `app/(tabs)/` — main app routes (home, radar, dash, plane, settings, etc.)
 - `app/api/cron/` — scheduled refreshes (snapshot, hotzones, predictor)
 - `public/sw.js` — service worker (push-only, no caching)
@@ -74,6 +77,15 @@ Audience: Puget Sound motorcyclists. Brand voice: dark theme, mono numerics,
   intentionally empty — `vercel env pull` cannot decrypt sensitive
   vars from production. Generate fresh values manually if you need
   push to work in preview deploys.
+- KV key construction: route through `lib/storage-keys.ts` (`trackKey()`,
+  `spotKey()`, `hotzonesCurrentKey()`, etc.) instead of inlining
+  string literals like `\`tracks:\${tail}:\${date}\``. The default-region
+  shape is byte-for-byte identical to the prior literals; the
+  formatter is the only knob for future regional namespacing.
+- ArmAlertsCallout returns null on iOS Safari (Notification API
+  absent) — that's correct behavior; the IOSInstallPrompt handles
+  riders in that path. The verify-prod assertion #9 was updated in
+  P16 to recognize either rendered surface as a pass.
 
 ## Brand voice
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,6 +27,17 @@ backfill (N2 → not viable on adsb.fi). One PR (#59, /about tail
 registry 2-col grid) left open for aesthetic review of the
 multi-column desktop direction.
 
+**P16 sweep (2026-05-02):** Fixed the Arm-alerts CTA first-visit
+regression (PR #61 — render synchronously instead of waiting on SW),
+shipped N1a speed-warning DRY-RUN logging (#63), shipped NX7
+federation namespace prep (#62 — `lib/storage-keys.ts`), shipped
+FilterPanel multi-select Roles section (#64). NX2 (weather overlay)
+and NX8 (time-scrubber) deferred to focused prompts (substantial
+work, design decisions needed). Verify-prod assertion #9 fixed to
+recognize iOS Safari's correct null-render path (component hides
+because Notification API is absent — IOSInstallPrompt covers riders
+in that context).
+
 
 
 Built and shipped: home glanceable, radar with hot-zone heatmap, weekly
@@ -50,23 +61,18 @@ needle vs which ones risk pulling it off-brand or out of scope.
 Side-project-sized work. Effort XS or S, no major brand tension, concrete
 user value visible at first paint.
 
-### N1a. Speed-warning DRY-RUN logging
-- **Description:** Wire the speed-warning trigger logic without surfacing
-  any UI. When the rider's speed exceeds the limit AND inside an active
-  hot zone AND a tracked plane is airborne within 5nm, fire a
-  `console.log` (and optionally a fetch to `/api/spot` with a `dry-run=1`
-  flag) so we can collect data on how often the trigger would fire and
-  on what cadence — without false-alarming any rider.
-- **Why it matters:** The threshold calculus is brand-critical. False
-  alarms on cruise-control are worse than no warnings. Dry-run gives us
-  a week of trigger-rate data before we surface anything user-visible.
-- **Effort:** S
-- **Risk:** low — no UI, no notifications, just instrumented logging.
-- **Brand tension:** none.
-- **Dependencies:** posted-speed-limit data source + hot-zone
-  proximity helper (neither currently exist; both must be designed
-  first). DEFERRED in P9.
-- **Status:** blocked on dependencies; needs a focused-session prompt.
+### N1a. Speed-warning DRY-RUN logging ✓ SHIPPED (P16 #63)
+- **Description:** `lib/speed-warning.ts` exposes `evaluateWarning()`,
+  a pure function that returns `wouldFire` + the three distance/over-
+  limit metrics. DashShell runs it on every rider geolocation tick
+  and POSTs positives to `/api/dryrun-warnings`. Admin viewer at
+  `/admin/dryrun-warnings`.
+- **Trigger condition:** all three of (a) over the limit by > 2 mph,
+  (b) inside a hot zone (≤ 0.5 nm from cell center), (c) tracked
+  alert-tier plane airborne ≤ 5 nm of the rider.
+- **Storage:** `dryrun-warnings:{YYYYMMDD}` Redis list, 7-day TTL.
+- **Status:** Live. Data accumulation begins now; N1b unblocks after
+  5–7 days of samples.
 
 ### N1b. Speed-warning UI surface
 - **Description:** Once N1a's data confirms the trigger threshold is
@@ -78,8 +84,8 @@ user value visible at first paint.
 - **Risk:** med — brand-critical UX.
 - **Brand tension:** none — `warn` is reserved.
 - **Dependencies:** N1a (need 5–7 days of dry-run data to set the
-  threshold).
-- **Status:** queued behind N1a.
+  threshold). N1a SHIPPED 2026-05-02 — eligible to ship around 2026-05-09.
+- **Status:** ready to write a prompt once N1a data accumulates.
 
 ### N2. adsb.fi historical backfill ✗ DEPRECATED (P15 #58)
 - **Investigation result:** adsb.fi is a real-time ADS-B aggregator and
@@ -373,21 +379,19 @@ tradeoff conversation. New infra OK if it's commodity.
 - **Dependencies:** none.
 - **Status:** ready to write a prompt.
 
-### NX7. Federation-ready namespace prep
-- **Description:** Refactor the codebase to make region (`puget_sound`,
-  `bay_area`, `phoenix`, etc) a first-class concept in storage keys + URL
-  routing. Doesn't ship a second region — just makes adding one a config
-  change instead of a refactor. See Tier 3 federation for the rest of the
-  story.
-- **Why it matters:** If we ever want to franchise the codebase, we want
-  the foundation laid before there's traffic to migrate.
-- **Effort:** M — touches every storage key (`tracks:*`, `spots:*`,
-  `hotzones:*`, `flights:*`) and the cron schedules.
-- **Risk:** med — schema migration of existing KV data needs care.
-- **Brand tension:** none.
-- **Dependencies:** none.
-- **Status:** decide whether federation is real ambition (T3) before
-  taking this on.
+### NX7. Federation-ready namespace prep ✓ FOUNDATION SHIPPED (P16 #62)
+- **Description:** `lib/storage-keys.ts` is now the canonical KV key
+  formatter. `tracks:*`, `spots:*`, `hotzones:*`, `flights:*` keys all
+  route through it. For `DEFAULT_REGION = 'puget-sound'` the formatter
+  returns byte-for-byte identical key shapes to the prior literals —
+  zero migration of existing data. For non-default regions a
+  `{region}:` prefix is prepended.
+- **What's left for actual Bay Area expansion:** per-region runtime
+  selection (currently hardcoded to default), cron-config per region,
+  per-region env vars (`SS_REGION_LAT/LON/NM` set today is single-
+  region). L6 Bay Area expansion is now ~3 days of config work
+  instead of ~3 weeks of refactoring.
+- **Status:** Foundation live; expansion remains an L6 decision.
 
 ### NX8. Time-scrubber for historical playback on `/radar`
 - **Description:** Promoted from L7 → NX. A scrub bar at the bottom

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -285,23 +285,83 @@ test.describe("p14 live-prod audit", () => {
   });
 
   test("9. alert opt-in card on home", async ({ page }) => {
+    // Headless Chromium defaults Notification.permission to "denied"
+    // (no UI means no opt-in dialog can ever show), and Playwright's
+    // grantPermissions(['notifications']) doesn't reliably flip the
+    // JS-visible Notification.permission property either. Real
+    // first-visit riders have permission "default" and see the Arm CTA.
+    // Override the property pre-document-load so the component takes
+    // the rider-realistic path.
+    await page.addInitScript(() => {
+      // Headless contexts that DO expose Notification often default
+      // permission to "denied". Override to "default" so the rider-
+      // realistic Arm CTA branch is exercised. Wrapped in typeof guard
+      // because some emulated UAs (WebKit-via-iPhone) don't expose the
+      // Notification API at all — accessing it throws.
+      try {
+        if (typeof Notification !== "undefined") {
+          Object.defineProperty(Notification, "permission", {
+            configurable: true,
+            get: () => "default",
+          });
+        }
+      } catch (_) {
+        /* best-effort */
+      }
+    });
     await page.goto("/", { waitUntil: "networkidle" });
     await page.waitForTimeout(2000);
     const screenshot = await shot(page, "09-home-armcta");
-    // ArmAlertsCallout self-hides if subscribed/denied/dismissed; in a
-    // fresh prod browser context it should render with text and a link
-    // to /settings/alerts.
+    // The ArmAlertsCallout component shows one of three surfaces:
+    //   1. The Arm CTA              (Notification.permission === "default")
+    //   2. The "Browser blocked"    (Notification.permission === "denied")
+    //   3. NULL on iOS Safari       (Notification API absent — by design)
+    //
+    // The chromium-mobile project emulates iPhone 15 Pro, which strips
+    // the Notification API from window — matching real iOS Safari. So
+    // case 3 (component correctly self-hides) is the rider-realistic
+    // outcome here, NOT a bug. The IOSInstallPrompt component covers
+    // the rider in that case, with its own "Arm alerts" instructional
+    // text inside the install dialog.
+    //
+    // Probe + accept any of the three valid surfaces.
+    const hasNotif = await page.evaluate(() => {
+      try {
+        return typeof Notification !== "undefined";
+      } catch (_) {
+        return false;
+      }
+    });
     const armLink = await page
       .locator('a[href="/settings/alerts"]:has-text("Arm")')
       .count();
+    const blockedText = await page
+      .locator(':has-text("Browser blocked alerts")')
+      .count();
+    // Look for the IOSInstallPrompt's distinctive "Add to Home Screen"
+    // step copy. Robust to quote-character variants.
+    const iosInstructions = await page
+      .locator(':has-text("Add to Home Screen")')
+      .count();
+    const visible =
+      armLink > 0 ||
+      blockedText > 0 ||
+      // On iOS-class UAs without Notification, IOSInstallPrompt is
+      // the rider-correct surface.
+      (!hasNotif && iosInstructions > 0);
+    const evidence =
+      armLink > 0
+        ? `${armLink} "Arm" CTA(s) found linking to /settings/alerts`
+        : blockedText > 0
+          ? "blocked-state surface rendered (permission denied)"
+          : !hasNotif && iosInstructions > 0
+            ? "iOS install instructions rendered (Notification API absent — correct for iOS Safari)"
+            : 'no "Arm" CTA, blocked-state, or iOS install instructions found';
     record({
       claim: "Arm-alerts CTA visible on / for new visitors",
-      category: armLink > 0 ? "working_as_designed" : "confirmed_bug",
-      pass: armLink > 0,
-      evidence:
-        armLink > 0
-          ? `${armLink} "Arm" CTA(s) found linking to /settings/alerts`
-          : 'no "Arm" CTA found — ArmAlertsCallout may have self-hidden or not deployed',
+      category: visible ? "working_as_designed" : "confirmed_bug",
+      pass: visible,
+      evidence,
       screenshot,
     });
   });


### PR DESCRIPTION
## Summary
P16 wrap-up: spec fix for verify-prod assertion #9, plus ROADMAP + CLAUDE.md sync.

### verify-prod assertion #9 — now iOS-aware
The `chromium-mobile` Playwright project emulates iPhone 15 Pro, which strips the `Notification` API from `window`. ArmAlertsCallout correctly self-hides when push isn't supported — that's the rider-realistic path on iOS Safari, where IOSInstallPrompt covers them with its own "Arm alerts" instructional copy in the install dialog.

The assertion now PASSES when **any** of the three valid surfaces renders:
1. The Arm CTA (`Notification.permission === "default"`)
2. The "Browser blocked" message (`permission === "denied"`)
3. The IOSInstallPrompt's "Add to Home Screen" instructions (Notification API absent)

Plus an `addInitScript` override for chromium contexts that DO expose Notification but default to "denied" headlessly.

### ROADMAP
- N1a → SHIPPED with impl summary
- NX7 → FOUNDATION SHIPPED + what's-still-needed for actual expansion
- P16 sweep paragraph in "Where we are right now"

### CLAUDE.md
- Architecture quick-ref: lib/speed-warning.ts, lib/storage-keys.ts, components/FilterPanel.tsx
- Operational notes: KV key construction routes through storage-keys.ts; ArmAlertsCallout iOS-null is correct

## Test plan
- [x] `npm run verify-prod` shows assertion #9 → PASS (iOS install instructions rendered)
- [ ] Doc cross-references match shipped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)