### PR TITLE
fix(learning-panel): "LEARNING THE SKY" — subject is the sky, not the rider

### DIFF
--- a/components/LearningPanel.tsx
+++ b/components/LearningPanel.tsx
@@ -1,4 +1,4 @@
-// Canonical "Learning your sky" panel — three variants of the same
+// Canonical "Learning the sky" panel — three variants of the same
 // content. Used wherever a surface depends on hot-zone or forecast data
 // that's still being collected. Single component so the copy + day
 // counter never disagree across home, radar, and forecast.
@@ -38,8 +38,8 @@ export function LearningPanel({
   const day = state.daysElapsed;
   const cap = LEARNING_THRESHOLD_DAYS;
   const eyebrow = state.stillLearning
-    ? `LEARNING YOUR SKY · DAY ${day} OF ${cap}`
-    : `LEARNING YOUR SKY · ${cap}+ DAYS IN`;
+    ? `LEARNING THE SKY · DAY ${day} OF ${cap}`
+    : `LEARNING THE SKY · ${cap}+ DAYS IN`;
 
   if (variant === "banner") {
     return (

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -401,4 +401,26 @@ test.describe("p14 live-prod audit", () => {
       screenshot,
     });
   });
+
+  test("11. learning panel reads 'the sky' not 'your sky' (P19 2.4)", async ({
+    page,
+  }) => {
+    await page.goto("/forecast", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "11-learning-panel-voice");
+    const html = (await page.content()).toUpperCase();
+    const hasOldCopy = html.includes("LEARNING YOUR SKY");
+    const hasNewCopy = html.includes("LEARNING THE SKY");
+    const pass = !hasOldCopy && hasNewCopy;
+    record({
+      claim:
+        'Learning panel eyebrow reads "LEARNING THE SKY" (not "YOUR SKY") to defuse the user-watching ambiguity',
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? '"LEARNING THE SKY" rendered, "LEARNING YOUR SKY" absent'
+        : `hasOld=${hasOldCopy} hasNew=${hasNewCopy} — copy fix did not ship or panel not rendered`,
+      screenshot,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P18 consensus aggregator flagged that the eyebrow "LEARNING YOUR SKY" reads as user-tracking to two personas (skeptic, lurker). Body copy already says "we've watched the sky for X days," so the eyebrow was the only ambiguous surface.

Change "LEARNING YOUR SKY" → "LEARNING THE SKY" in both states (still-learning and past-threshold).

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertion #11 added — checks /forecast for "LEARNING THE SKY" present and "LEARNING YOUR SKY" absent
- [ ] CI build gate

## Reference

\`out/persona-walks/sweep-2026-05-02T11-00-33/consensus.md\` finding 12 ("Learning your sky" copy is ambiguous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)