### PR TITLE
fix(plane-detail): distinguish 'Last flew' / 'Last contact' / 'Last position broadcast'

### DIFF
--- a/app/(tabs)/plane/[tail]/page.tsx
+++ b/app/(tabs)/plane/[tail]/page.tsx
@@ -129,13 +129,15 @@ export default async function PlanePage({ params, searchParams }: Props) {
                 ? fmtAloft(live?.time_aloft_min)
                 : recentFlight
                   ? `Last flew ${fmtAgoTs(recentFlight.session.end_ts)}`
-                  : `last seen ${fmtAgo(live?.last_seen_min)}`
+                  : live?.last_seen_min != null
+                    ? `Last contact ${fmtAgo(live.last_seen_min)}`
+                    : "No recent contact"
             }
             big
             tooltip={
               up
                 ? "Live state from latest ADS-B observation."
-                : "Some helicopters fly with intermittent transponder coverage; 'last seen' isn't always 'last flew'."
+                : "Some helicopters fly with intermittent transponder coverage; 'last contact' (most recent ADS-B trace) isn't always 'last flew' (most recent completed flight session)."
             }
           />
           <Tooltip content={roleTooltip(entry.role)}>
@@ -252,17 +254,24 @@ function LiveDataBlock({
 }
 
 function GroundedNote({ live }: { live: Aircraft | undefined }) {
+  const lastSeen = live?.last_seen_min;
   return (
     <Card>
       <div className="ss-eyebrow" style={{ marginBottom: 6 }}>
         Currently
       </div>
       <div style={{ fontSize: 14, color: SS_TOKENS.fg1 }}>
-        On the ground. Last seen{" "}
-        <span className="ss-mono" style={{ color: SS_TOKENS.fg0 }}>
-          {fmtAgo(live?.last_seen_min)}
-        </span>{" "}
-        back.
+        {lastSeen != null ? (
+          <>
+            On the ground. Last position broadcast{" "}
+            <span className="ss-mono" style={{ color: SS_TOKENS.fg0 }}>
+              {fmtAgo(lastSeen)}
+            </span>{" "}
+            back.
+          </>
+        ) : (
+          "On the ground. Awaiting next position broadcast."
+        )}
       </div>
     </Card>
   );

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -423,4 +423,32 @@ test.describe("p14 live-prod audit", () => {
       screenshot,
     });
   });
+
+  test("12. /plane/[tail] no duplicate 'Last seen' (P19 2.2)", async ({
+    page,
+  }) => {
+    await page.goto("/plane/N305DK", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "12-plane-last-seen-dedupe");
+    const body = await page.locator("main").innerText();
+    // The persona finding: "Last seen a while" appeared in both the
+    // header status pill and the Currently card. Post-fix, the two
+    // surfaces use distinct labels:
+    //   - StatusPill sub: "Last flew" or "Last contact" or "No recent contact"
+    //   - GroundedNote:   "Last position broadcast" or "Awaiting next position broadcast"
+    // The exact "Last seen a while" string must not appear at all.
+    const hasLastSeenAWhile = /last seen.*a while|a while.*last seen/i.test(body);
+    const lastSeenCount = (body.match(/last seen/gi) ?? []).length;
+    const pass = !hasLastSeenAWhile && lastSeenCount === 0;
+    record({
+      claim:
+        '/plane/[tail] uses distinct labels for the header pill ("Last flew"/"Last contact") vs Currently card ("Last position broadcast")',
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? '"last seen" string absent; pill and card carry distinct labels'
+        : `"last seen" appeared ${lastSeenCount}x; legacy duplicate may have regressed`,
+      screenshot,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P18 consensus aggregator: 4 personas (local-journalist, operator, out-of-tz-onlooker, sport-bike-rider) flagged the duplicate "Last seen a while" appearing in both the header status pill and the Currently card on /plane/[tail]. Same string, two surfaces — read as a UI bug.

The two signals were already different:
- **StatusPill sub** → most recent completed flight session (or fallback to ADS-B trace)
- **GroundedNote** → most recent ADS-B position broadcast

Now uses distinct labels so users can tell them apart. Kills the "last seen a while" pattern entirely.

| Surface | Old | New |
|---|---|---|
| Pill (recent flight) | "Last flew Xh ago" | (unchanged) |
| Pill (no flight, has ADS-B) | "last seen a while" | "Last contact Xm ago" |
| Pill (no signal) | "last seen a while" | "No recent contact" |
| Currently card (has ADS-B) | "Last seen X back" | "Last position broadcast X back" |
| Currently card (no signal) | "Last seen a while back" | "Awaiting next position broadcast" |

Tooltip on the pill explains the distinction.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertion #12 added — fails if "last seen" reappears on /plane/[tail]
- [ ] CI build gate

## Reference

\`out/persona-walks/sweep-2026-05-02T11-00-33/consensus.md\` finding 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)