### PR TITLE
fix(time): explicit PT clock on FreshnessLabel + /activity rows

### DIFF
--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { SS_TOKENS } from "@/lib/tokens";
 import type { ActivityEntry, ActivityKind } from "@/lib/activity";
-import { fmtAgoTs } from "@/lib/time";
+import { fmtAgoTs, formatTsBare } from "@/lib/time";
 
 const TABBAR_HEIGHT = 66;
 
@@ -144,7 +144,7 @@ function Row({ entry, first }: { entry: ActivityEntry; first: boolean }) {
           className="ss-mono"
           style={{ fontSize: 11, color: SS_TOKENS.fg2, marginTop: 2 }}
         >
-          {fmtAgoTs(entry.ts)}
+          {fmtAgoTs(entry.ts)} · {formatTsBare(entry.ts, "hour-min")} PT
         </div>
       </div>
       <span

--- a/components/FreshnessLabel.tsx
+++ b/components/FreshnessLabel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { SS_TOKENS } from "@/lib/tokens";
 import { STALE_MS } from "@/lib/freshness";
+import { formatTsBare } from "@/lib/time";
 
 type Props = {
   /** ms-since-epoch of the last successful track sample. null = unknown. */
@@ -37,6 +38,7 @@ export function FreshnessLabel({ lastSampleMs, className, style }: Props) {
   const stale = ageMs > STALE_MS;
   const m = Math.floor(ageMs / 60_000);
   const label = m < 1 ? "JUST NOW" : `${m}m AGO`;
+  const clock = formatTsBare(lastSampleMs, "hour-min");
   return (
     <span
       className={`ss-mono ${className ?? ""}`}
@@ -52,7 +54,7 @@ export function FreshnessLabel({ lastSampleMs, className, style }: Props) {
           : undefined
       }
     >
-      LAST SAMPLE — {label}
+      LAST SAMPLE — {label} · {clock} PT
     </span>
   );
 }

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -451,4 +451,57 @@ test.describe("p14 live-prod audit", () => {
       screenshot,
     });
   });
+
+  test("13a. home FreshnessLabel includes PT clock (P19 2.1)", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "13a-home-freshness-pt");
+    const body = await page.locator("main").innerText();
+    // Pattern: "LAST SAMPLE — JUST NOW · 15:37 PT" or "LAST SAMPLE — 12m AGO · 15:25 PT"
+    const hasFreshnessPt =
+      /LAST SAMPLE\s+—\s+(JUST NOW|\d+m AGO)\s+·\s+\d{2}:\d{2}\s+PT/i.test(
+        body,
+      );
+    const hasUnknown = /LAST SAMPLE\s+—\s+UNKNOWN/i.test(body);
+    const pass = hasFreshnessPt || hasUnknown;
+    record({
+      claim:
+        "Home 'LAST SAMPLE' footer carries explicit 'HH:MM PT' so out-of-region readers don't have to infer the reference frame",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? hasFreshnessPt
+          ? "PT clock format present in FreshnessLabel"
+          : "UNKNOWN state (no live sample) — accepted"
+        : "FreshnessLabel rendered without 'HH:MM PT' suffix",
+      screenshot,
+    });
+  });
+
+  test("13b. /activity rows include PT clock (P19 2.1)", async ({ page }) => {
+    await page.goto("/activity", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "13b-activity-pt-clock");
+    const body = await page.locator("main").innerText();
+    // Pattern: "12m ago · 15:42 PT" or "just now · 15:42 PT"
+    const hasActivityPt =
+      /(\d+[mhd]\s+ago|just now)\s+·\s+\d{2}:\d{2}\s+PT/i.test(body);
+    // Empty state acceptable (no rows yet)
+    const isEmpty = /Watching the sky/i.test(body);
+    const pass = hasActivityPt || isEmpty;
+    record({
+      claim:
+        "/activity row metadata pairs relative ('12m ago') with absolute PT ('15:42 PT') so the journalist persona can cite times",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? hasActivityPt
+          ? "row metadata includes 'HH:MM PT'"
+          : "empty state — accepted"
+        : "activity rows render relative time only, no PT clock",
+      screenshot,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P18 consensus aggregator finding 7 — "No timezone label anywhere in the app; Pacific time is assumed but never stated." Raised by out-of-tz-onlooker on every route and local-journalist on /activity.

Two surfaces patched:

| Surface | Old | New |
|---|---|---|
| FreshnessLabel (home + radar) | "LAST SAMPLE — 12m AGO" | "LAST SAMPLE — 12m AGO · 15:25 PT" |
| ActivityFeed rows | "12m ago" | "12m ago · 15:42 PT" |

Both use \`formatTsBare\` from \`lib/time.ts\` so the existing PT-anchored formatter remains the single source of truth. The /forecast cell detail already labels its hour as "PT" (no change there).

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertions #13a + #13b added
- [ ] CI build gate

## Reference

\`out/persona-walks/sweep-2026-05-02T11-00-33/consensus.md\` finding 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)