### PR TITLE
feat(ci): brand-voice gate on every PR — regex/wordlist, no auth

### DIFF
--- a/.github/scripts/voice-gate.mjs
+++ b/.github/scripts/voice-gate.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Brand-voice gate. Reads changed user-facing files via stdin (one path
+// per line), emits {p0,p1} JSON to stdout, exits 1 if any P0 violation.
+// Pure regex/wordlist — no LLM, no network. Rules from design/BRAND.md.
+
+import { readFileSync, existsSync } from "node:fs";
+import { extname } from "node:path";
+
+const P0_BANNED = [
+  ["police", 'use "Smokey" / "the bird"'],
+  ["cop", 'use "Smokey" / "the bird"'],
+  ["law enforcement", 'use "Smokey"'],
+  ["drone", "drones aren't the bird"],
+  ["surveilling", 'use "watching"'],
+  ["surveillance state", "anti-cop framing is brand-toxic"],
+  ["snitch", "anti-cop framing"],
+  ["outrun the bird", "the app *informs*, it does not *evade*"],
+  ["evade", "frame as situational awareness, not evasion"],
+];
+
+const P1_DISCOURAGED = [
+  ["the plane", 'prefer "the bird" or "Smokey"'],
+  ["the aircraft", 'prefer "the bird" in rider-facing copy'],
+  ["active patrol", 'prefer "up" / "watching"'],
+  ["inactive", 'prefer "down"'],
+  ["monitoring", 'prefer "watching"'],
+  ["slow down", 'prefer "ease off"'],
+  ["Smoky", 'canonical spelling is "Smokey" with the e'],
+];
+
+const EMOJI_RE = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{1F000}-\u{1F2FF}]/u;
+const EXCL_RE = /[A-Za-z]\!(\s|$|")/;
+
+function extractStrings(text, ext) {
+  const out = [];
+  if (ext === ".md" || ext === ".mdx") {
+    text.split("\n").forEach((line, i) => {
+      if (line.startsWith("```") || line === "---") return;
+      out.push({ text: line, line: i + 1 });
+    });
+    return out;
+  }
+  const ATTR_RE =
+    /(?:aria-label|title|alt|placeholder|label|content|description|aria-describedby)=(?:"([^"]+)"|\{`([^`]+)`\}|\{"([^"]+)"\})/g;
+  const JSX_RE = />([^<>{}\n]{4,})</g;
+  const META_RE = /^\s*(?:title|description):\s*"([^"]+)"/;
+  text.split("\n").forEach((line, i) => {
+    let m;
+    while ((m = ATTR_RE.exec(line))) {
+      const v = m[1] ?? m[2] ?? m[3];
+      if (v) out.push({ text: v, line: i + 1 });
+    }
+    while ((m = JSX_RE.exec(line))) {
+      const v = m[1].trim();
+      if (v && /[A-Za-z]/.test(v)) out.push({ text: v, line: i + 1 });
+    }
+    const meta = META_RE.exec(line);
+    if (meta) out.push({ text: meta[1], line: i + 1 });
+  });
+  return out;
+}
+
+function check(s) {
+  const v = [];
+  const lower = s.text.toLowerCase();
+  for (const [word, reason] of P0_BANNED) {
+    if (lower.includes(word.toLowerCase())) v.push({ severity: "P0", rule: word, reason });
+  }
+  if (EMOJI_RE.test(s.text))
+    v.push({ severity: "P0", rule: "emoji", reason: "BRAND.md §3 — zero emoji in product copy" });
+  if (EXCL_RE.test(s.text))
+    v.push({ severity: "P0", rule: "exclamation", reason: "BRAND.md §3 — no exclamation marks, ever" });
+  for (const [word, reason] of P1_DISCOURAGED) {
+    if (new RegExp(`\\b${word}\\b`, "i").test(s.text))
+      v.push({ severity: "P1", rule: word, reason });
+  }
+  return v;
+}
+
+function isUserFacing(p) {
+  if (p.startsWith("app/(tabs)/") && p.endsWith("page.tsx")) return true;
+  if (p.startsWith("components/") && p.endsWith(".tsx") && !/(?:admin|debug|dev[-_])/i.test(p))
+    return true;
+  if (p === "public/manifest.json" || p === "app/layout.tsx") return true;
+  if (p.startsWith("content/") && /\.mdx?$/.test(p)) return true;
+  return false;
+}
+
+const paths = readFileSync(0, "utf8")
+  .split("\n").map((s) => s.trim()).filter(Boolean).filter(isUserFacing);
+const findings = [];
+for (const p of paths) {
+  if (!existsSync(p)) continue;
+  const text = readFileSync(p, "utf8");
+  for (const s of extractStrings(text, extname(p))) {
+    for (const v of check(s)) {
+      findings.push({ ...v, path: p, line: s.line, snippet: s.text.slice(0, 120) });
+    }
+  }
+}
+const p0 = findings.filter((f) => f.severity === "P0");
+const p1 = findings.filter((f) => f.severity === "P1");
+process.stdout.write(JSON.stringify({ p0, p1 }, null, 2) + "\n");
+process.stderr.write(
+  `voice-gate: ${p0.length} P0, ${p1.length} P1 — ${p0.length > 0 ? "FAIL" : "pass"}\n`,
+);
+process.exit(p0.length > 0 ? 1 : 0);

--- a/.github/workflows/voice-gate.yml
+++ b/.github/workflows/voice-gate.yml
@@ -1,0 +1,75 @@
+name: Voice gate
+
+# Brand-voice CI gate. Pure regex/wordlist (no LLM, no auth, no network).
+# Source of truth: design/BRAND.md §3 + §8. Fails on P0 (banned vocab,
+# emoji, exclamation marks); P1 nudges post a comment but don't block.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: voice-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  voice-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+
+      - name: Compute changed files
+        run: |
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}..." \
+            "${{ github.event.pull_request.head.sha }}" \
+            | tee /tmp/changed.txt
+
+      - name: Run voice gate
+        id: gate
+        run: |
+          set +e
+          node .github/scripts/voice-gate.mjs < /tmp/changed.txt > /tmp/findings.json 2> /tmp/gate.err
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          cat /tmp/findings.json
+          cat /tmp/gate.err >&2 || true
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let f;
+            try { f = JSON.parse(fs.readFileSync('/tmp/findings.json', 'utf8')); }
+            catch { return; }
+            const { p0 = [], p1 = [] } = f;
+            if (p0.length === 0 && p1.length === 0) return;
+            const fmt = (x) => `- \`${x.path}:${x.line}\` **${x.rule}** — ${x.reason}\n  > ${x.snippet}`;
+            const body = [
+              `## Voice gate findings`, ``,
+              p0.length ? `### P0 — blocks merge\n\n${p0.map(fmt).join('\n')}` : '',
+              p1.length ? `### P1 — warning\n\n${p1.map(fmt).join('\n')}` : '',
+              ``,
+              `_Rules: \`design/BRAND.md\` §3 + §8. Heuristic catches attribute strings, single-line JSX text, Markdown prose, and metadata. Multi-line JSX text is a known gap._`,
+            ].filter(Boolean).join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+      - name: Fail if P0
+        if: steps.gate.outputs.exit != '0'
+        run: exit 1


### PR DESCRIPTION
## Summary

P20 Phase 3 — continuous brand-voice enforcement so \`design/BRAND.md\` rules don't drift via incremental PRs.

Pure regex/wordlist. No LLM, no API key, no network. <30s on ubuntu-latest.

## What it catches

| Severity | Action | Catches |
|---|---|---|
| **P0** | Blocks merge | Banned vocab (police, cop, drone, surveilling, evade, outrun the bird, snitch, etc.); emoji; exclamation marks |
| **P1** | Posts comment, warning only | Preferred-vocab nudges (the plane → the bird, monitoring → watching, slow down → ease off, Smoky → Smokey) |

## User-facing scope

- \`app/(tabs)/*/page.tsx\`
- \`components/*.tsx\` (excluding admin/debug/dev)
- \`public/manifest.json\`
- \`app/layout.tsx\`
- \`content/*.{md,mdx}\`

Heuristic extraction covers: attribute strings (aria-label, title, alt, placeholder, label, content, description), single-line JSX text, Markdown prose, exported metadata.title|description. Multi-line JSX text is a known gap; documented in the workflow.

## Test plan

- [x] \`node .github/scripts/voice-gate.mjs\` smoke-test catches "cop" + exclamation mark + emoji on a fixture
- [x] Smoke-test against current main rider-facing files: 0 P0 / 0 P1 (clean baseline)
- [x] Workflow valid YAML
- [ ] CI runs on this PR (no rider-facing files touched here, so the workflow should pass with empty findings)
- [ ] **Verify after merge:** open a deliberate-violation PR (emoji in JSX text, "cop" in aria-label) and confirm the gate fails

## Lines

182 total (107 script + 75 workflow). Within the ≤200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)