### PR TITLE
feat(mock): expand ?mock state machine — eyes-up, multiple, stale

### DIFF
--- a/app/(tabs)/dash/page.tsx
+++ b/app/(tabs)/dash/page.tsx
@@ -1,7 +1,7 @@
 import { DashShell } from "@/components/DashShell";
 import { getSnapshot } from "@/lib/snapshot";
 import { getRecentActivity } from "@/lib/activity";
-import { mockAirborneSnapshot } from "@/lib/mock";
+import { applyMockState, parseMockState } from "@/lib/mock-state";
 
 export const metadata = {
   title: "SmokySignal · Dash",
@@ -20,7 +20,8 @@ export default async function DashPage({
     getSnapshot(),
     getRecentActivity(10),
   ]);
-  const mockOn = searchParams.mock === "up";
-  const initial = mockOn ? mockAirborneSnapshot(real) : real;
+  const mockState = parseMockState(searchParams.mock);
+  const mockOn = mockState !== null;
+  const initial = applyMockState(real, mockState);
   return <DashShell initial={initial} initialActivity={activity} mockOn={mockOn} />;
 }

--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -1,6 +1,6 @@
 import { Glanceable } from "@/components/Glanceable";
 import { getSnapshot } from "@/lib/snapshot";
-import { mockAirborneSnapshot } from "@/lib/mock";
+import { applyMockState, parseMockState } from "@/lib/mock-state";
 import { getRecentActivity } from "@/lib/activity";
 import { getLearningState } from "@/lib/learning";
 import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
@@ -22,8 +22,9 @@ export default async function Page({
     getLearningState(),
     getFreshness(),
   ]);
-  const mockOn = searchParams.mock === "up";
-  const initial = mockOn ? mockAirborneSnapshot(real) : real;
+  const mockState = parseMockState(searchParams.mock);
+  const mockOn = mockState !== null;
+  const initial = applyMockState(real, mockState);
   const hour12 = isHour12(getTimeFormatPref());
   // Historical context line — null when learning, sparse, or no bucket data.
   const isCurrentlyUp = initial.aircraft.some((a) => a.airborne);

--- a/app/(tabs)/plane/[tail]/page.tsx
+++ b/app/(tabs)/plane/[tail]/page.tsx
@@ -3,7 +3,7 @@ import nextDynamic from "next/dynamic";
 import { fleetHex } from "@/lib/seed";
 import { getRegistry } from "@/lib/registry";
 import { getSnapshot } from "@/lib/snapshot";
-import { mockAirborneSnapshot } from "@/lib/mock";
+import { applyMockState, parseMockState } from "@/lib/mock-state";
 import { getMostRecentFlightForTail, flightIdFromTs } from "@/lib/flights";
 import { SS_TOKENS } from "@/lib/tokens";
 import { StatusPill } from "@/components/StatusPill";
@@ -58,7 +58,7 @@ export default async function PlanePage({ params, searchParams }: Props) {
   const entry = fleet.find((f) => f.tail === tail);
   if (!entry) notFound();
   const recentFlight = await getMostRecentFlightForTail(tail, entry.nickname);
-  const snap = searchParams.mock === "up" ? mockAirborneSnapshot(real) : real;
+  const snap = applyMockState(real, parseMockState(searchParams.mock));
 
   const live = snap.aircraft.find((a) => a.tail === tail);
   const up = Boolean(live?.airborne);

--- a/app/(tabs)/radar/page.tsx
+++ b/app/(tabs)/radar/page.tsx
@@ -1,6 +1,6 @@
 import { RadarShell } from "@/components/RadarShell";
 import { getSnapshot } from "@/lib/snapshot";
-import { mockAirborneSnapshot } from "@/lib/mock";
+import { applyMockState, parseMockState } from "@/lib/mock-state";
 import { getLearningState } from "@/lib/learning";
 import { getFreshness } from "@/lib/freshness";
 
@@ -22,8 +22,9 @@ export default async function RadarPage({
     getLearningState(),
     getFreshness(),
   ]);
-  const mockOn = searchParams.mock === "up";
-  const initial = mockOn ? mockAirborneSnapshot(real) : real;
+  const mockState = parseMockState(searchParams.mock);
+  const mockOn = mockState !== null;
+  const initial = applyMockState(real, mockState);
   return (
     <RadarShell
       initial={initial}

--- a/app/api/aircraft/route.ts
+++ b/app/api/aircraft/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { getSnapshot } from "@/lib/snapshot";
-import { isMockOn, mockAirborneSnapshot } from "@/lib/mock";
+import { applyMockState, getMockStateFromRequest } from "@/lib/mock-state";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   const snap = await getSnapshot();
-  const out = isMockOn(req) ? mockAirborneSnapshot(snap) : snap;
+  const out = applyMockState(snap, getMockStateFromRequest(req));
   return NextResponse.json(out, {
     headers: {
       // Browser won't cache; CDN can hold the same 10s the server does.

--- a/lib/mock-state.ts
+++ b/lib/mock-state.ts
@@ -1,0 +1,122 @@
+// Mock state machine for ?mock=<state> on rider-facing pages and API
+// routes. Deterministic — same query param yields the same response
+// shape, no randomness, no time-of-day drift.
+//
+// Snapshot-level states (this file): up, down, eyes-up, multiple, stale.
+//
+// Data-layer states (deferred to a follow-up): learning, full-data —
+// those need overrides in lib/learning.ts and lib/predictor.ts. Tracking
+// in the issue queue.
+
+import type { Snapshot, FleetRole } from "./types";
+
+export const MOCK_STATES = [
+  "up",
+  "down",
+  "eyes-up",
+  "multiple",
+  "stale",
+] as const;
+export type MockState = (typeof MOCK_STATES)[number];
+
+const TAIL_OVERRIDES: Record<
+  string,
+  Partial<{
+    lat: number;
+    lon: number;
+    altitude_ft: number;
+    ground_speed_kt: number;
+    heading: number;
+    time_aloft_min: number;
+    squawk: string | null;
+  }>
+> = {
+  N305DK: {
+    lat: 47.5301,
+    lon: -122.2612,
+    altitude_ft: 2800,
+    ground_speed_kt: 118,
+    heading: 184,
+    time_aloft_min: 47,
+    squawk: "1234",
+  },
+  N422CT: {
+    lat: 47.671,
+    lon: -122.3345,
+    altitude_ft: 1400,
+    ground_speed_kt: 88,
+    heading: 270,
+    time_aloft_min: 12,
+    squawk: "1200",
+  },
+};
+
+function liftAirborne(
+  snap: Snapshot,
+  predicate: (role: FleetRole) => boolean,
+  cap?: number,
+): Snapshot {
+  let lifted = 0;
+  return {
+    ...snap,
+    source: "mock",
+    aircraft: snap.aircraft.map((a) => {
+      if (!predicate(a.role)) return a;
+      if (cap != null && lifted >= cap) return a;
+      lifted++;
+      const o = TAIL_OVERRIDES[a.tail] ?? {};
+      return {
+        ...a,
+        ...o,
+        airborne: true,
+        last_seen_min: 0,
+      };
+    }),
+  };
+}
+
+export function parseMockState(value: string | null | undefined): MockState | null {
+  if (!value) return null;
+  return (MOCK_STATES as readonly string[]).includes(value) ? (value as MockState) : null;
+}
+
+export function getMockStateFromRequest(req: Request): MockState | null {
+  return parseMockState(new URL(req.url).searchParams.get("mock"));
+}
+
+export function applyMockState(snap: Snapshot, state: MockState | null): Snapshot {
+  if (!state) return snap;
+  switch (state) {
+    case "down":
+      // All clear — every aircraft grounded, even if upstream had something
+      // up. Useful for previewing the calm-sky home screen at any time.
+      return {
+        ...snap,
+        source: "mock",
+        aircraft: snap.aircraft.map((a) => ({ ...a, airborne: false })),
+      };
+    case "up":
+      // At least one smokey-class up. The original mock=up behavior.
+      return liftAirborne(snap, (r) => r === "smokey");
+    case "eyes-up":
+      // Patrol or unknown airborne, no smokey. Drives the EYES UP pill +
+      // the amber-but-not-SMOKEY home variant.
+      return liftAirborne(snap, (r) => r === "patrol" || r === "unknown");
+    case "multiple":
+      // 3 smokey-class + 1 patrol. Drives the "X up" pill sub and the
+      // others-also-up list.
+      return liftAirborne(
+        liftAirborne(snap, (r) => r === "smokey", 3),
+        (r) => r === "patrol",
+        1,
+      );
+    case "stale":
+      // Last sample > 15 min ago. Flips the FreshnessLabel amber and
+      // surfaces the "Live cron may be down" tooltip.
+      return {
+        ...snap,
+        source: "mock",
+        fetched_at: Date.now() - 16 * 60 * 1000,
+      };
+  }
+}

--- a/lib/mock.ts
+++ b/lib/mock.ts
@@ -1,55 +1,17 @@
-// Dev/preview-only: force two tails into an airborne state so the
-// "Smoky's watching." hero can be eyeballed when no plane is actually up.
-// Triggered via `?mock=up` on the page or API routes.
-//
-// Data mirrors design/data.jsx LIVE_SNAPSHOT for Smoky + Guardian.
+// Backward-compat shim. New code should use lib/mock-state.ts directly,
+// which supports the full mock state machine (?mock=up|down|eyes-up|
+// multiple|stale). This module preserves the original two exports so
+// historical call sites keep working through the migration.
 
 import type { Snapshot } from "./types";
+import { applyMockState, parseMockState } from "./mock-state";
 
-const OVERRIDES: Record<
-  string,
-  Partial<{
-    lat: number;
-    lon: number;
-    altitude_ft: number;
-    ground_speed_kt: number;
-    heading: number;
-    time_aloft_min: number;
-    squawk: string | null;
-  }>
-> = {
-  N305DK: {
-    lat: 47.5301,
-    lon: -122.2612,
-    altitude_ft: 2800,
-    ground_speed_kt: 118,
-    heading: 184,
-    time_aloft_min: 47,
-    squawk: "1234",
-  },
-  N422CT: {
-    lat: 47.671,
-    lon: -122.3345,
-    altitude_ft: 1400,
-    ground_speed_kt: 88,
-    heading: 270,
-    time_aloft_min: 12,
-    squawk: "1200",
-  },
-};
-
+/** Equivalent to `applyMockState(snap, "up")`. */
 export function mockAirborneSnapshot(snap: Snapshot): Snapshot {
-  return {
-    ...snap,
-    source: "mock",
-    aircraft: snap.aircraft.map((a) => {
-      const o = OVERRIDES[a.tail];
-      if (!o) return a;
-      return { ...a, ...o, airborne: true, last_seen_min: 0 };
-    }),
-  };
+  return applyMockState(snap, "up");
 }
 
+/** True iff `?mock=up` is set. New code should use `getMockStateFromRequest`. */
 export function isMockOn(req: Request): boolean {
-  return new URL(req.url).searchParams.get("mock") === "up";
+  return parseMockState(new URL(req.url).searchParams.get("mock")) === "up";
 }

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -539,4 +539,51 @@ test.describe("p14 live-prod audit", () => {
       screenshot,
     });
   });
+
+  test("15. ?mock=eyes-up returns patrol airborne, no smokey (P20 4.1)", async ({
+    request,
+  }) => {
+    const r = await request.get("/api/aircraft?mock=eyes-up");
+    const ok = r.ok();
+    let evidence = `HTTP ${r.status()}`;
+    let pass = false;
+    if (ok) {
+      const data = (await r.json()) as { aircraft: Array<{ role: string; airborne: boolean }> };
+      const airborne = data.aircraft.filter((a) => a.airborne);
+      const smokeyUp = airborne.some((a) => a.role === "smokey");
+      const patrolOrUnknownUp = airborne.some(
+        (a) => a.role === "patrol" || a.role === "unknown",
+      );
+      pass = !smokeyUp && patrolOrUnknownUp;
+      evidence = `${airborne.length} airborne; smokey=${smokeyUp ? "yes" : "no"}; patrol/unknown=${patrolOrUnknownUp ? "yes" : "no"}`;
+    }
+    record({
+      claim:
+        "?mock=eyes-up forces a patrol/unknown-class plane airborne with no smokey-class — drives the EYES UP pill variant",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence,
+    });
+  });
+
+  test("16. ?mock=stale returns old fetched_at (P20 4.1)", async ({
+    request,
+  }) => {
+    const r = await request.get("/api/aircraft?mock=stale");
+    let evidence = `HTTP ${r.status()}`;
+    let pass = false;
+    if (r.ok()) {
+      const data = (await r.json()) as { fetched_at: number; source: string };
+      const ageMin = Math.floor((Date.now() - data.fetched_at) / 60_000);
+      pass = ageMin >= 15 && data.source === "mock";
+      evidence = `fetched_at=${ageMin}m ago, source=${data.source}`;
+    }
+    record({
+      claim:
+        "?mock=stale returns fetched_at >15min ago with source='mock' — flips FreshnessLabel amber",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P20 Phase 4.1. The persona-walk harness needs reproducible test states beyond \`?mock=up\`. Adds a deterministic state machine in \`lib/mock-state.ts\` driving five snapshot-level variants.

| Param | Behavior |
|---|---|
| \`?mock=up\` | ≥1 smokey-role plane airborne (was: any tail with hardcoded overrides) |
| \`?mock=down\` | All aircraft grounded |
| \`?mock=eyes-up\` | Patrol/unknown airborne, no smokey — EYES UP pill variant |
| \`?mock=multiple\` | 3 smokeys + 1 patrol — "X up" pill sub + others-list |
| \`?mock=stale\` | \`fetched_at = now - 16min\` — flips FreshnessLabel amber |

Two data-layer states from the P20 spec (\`?mock=learning\`, \`?mock=full-data\`) defer to a follow-up issue — they need overrides in \`lib/learning.ts\` and the forecast/hot-zones layer that don't fit in this PR's budget.

## Backward compat

\`lib/mock.ts\` preserved as a shim (\`mockAirborneSnapshot\` + \`isMockOn\`) routing through the new state machine. New code should call \`applyMockState(snap, parseMockState(...))\`.

5 consumers updated: home, dash, radar, plane/[tail], /api/aircraft.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertions #15 + #16 added
- [ ] Manual: hit \`https://smokysignal.app/api/aircraft?mock=eyes-up\` and confirm patrol airborne, no smokey
- [ ] Manual: hit \`https://smokysignal.app/api/aircraft?mock=stale\` and confirm \`fetched_at\` is ~16 min old
- [ ] CI build gate

## Lines

194 added / 60 deleted — within the ≤200 budget.

## Reference

P20 spec Phase 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)