### PR TITLE
feat(ci): per-PR persona walks against Vercel preview

### DIFF
--- a/.github/scripts/affected-routes.mjs
+++ b/.github/scripts/affected-routes.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Map a list of changed file paths (stdin, one per line) to the route
+// subset that should be walked for this PR. Emits a comma-separated
+// route name list to stdout.
+//
+// Mapping:
+//   app/(tabs)/<X>/page.tsx → /X (or / for the root)
+//   components/*.tsx        → all routes (broad change)
+//   lib/*                   → all routes (broad)
+//   app/api/*               → all routes (API surfaces affect what pages render)
+// Anything outside those globs is ignored — the workflow returns the
+// empty string and the caller skips the walk.
+
+import { readFileSync } from "node:fs";
+
+const ALL_ROUTES = ["home", "radar", "forecast", "activity", "about", "legal", "help", "plane-N305DK"];
+
+// Tab-to-route-name lookup. The "name" field is what run-walk.ts expects
+// in --routes (matches tests/visual/personas/run-walk.ts ROUTES).
+const TAB_TO_NAME = new Map([
+  ["radar", "radar"],
+  ["forecast", "forecast"],
+  ["activity", "activity"],
+  ["about", "about"],
+  ["legal", "legal"],
+  ["help", "help"],
+  // /plane/[tail] is dynamic — represent any change as the canonical
+  // example tail used by the verify-prod spec.
+  ["plane", "plane-N305DK"],
+]);
+
+const paths = readFileSync(0, "utf8").split("\n").map((s) => s.trim()).filter(Boolean);
+const routes = new Set();
+let broad = false;
+
+for (const p of paths) {
+  if (p.startsWith("components/") && p.endsWith(".tsx")) broad = true;
+  else if (p.startsWith("lib/") && (p.endsWith(".ts") || p.endsWith(".tsx"))) broad = true;
+  else if (p.startsWith("app/api/")) broad = true;
+  else if (p === "app/(tabs)/page.tsx") routes.add("home");
+  else if (p === "app/layout.tsx") broad = true;
+  else {
+    const m = /^app\/\(tabs\)\/([^/]+)\//.exec(p);
+    if (m) {
+      const name = TAB_TO_NAME.get(m[1]);
+      if (name) routes.add(name);
+    }
+  }
+}
+
+const final = broad ? ALL_ROUTES : Array.from(routes);
+process.stdout.write(final.join(",") + "\n");

--- a/.github/workflows/persona-walk-pr.yml
+++ b/.github/workflows/persona-walk-pr.yml
@@ -1,0 +1,156 @@
+name: Persona walk on PR
+
+# Per-PR persona-walk against the Vercel preview deploy. 3 personas
+# (sport-bike-rider, skeptic, lurker) × routes inferred from the PR's
+# changed files. Posts a single comment with consensus findings.
+#
+# Auth path (one of):
+#   - CLAUDE_CODE_OAUTH_TOKEN — generate locally with `claude setup-token`,
+#     bills the operator's Max subscription. Preferred.
+#   - ANTHROPIC_API_KEY — fallback. Bills against an API key.
+# If neither is set, the workflow noops with a warning (no failure).
+#
+# Vercel deploy detection requires VERCEL_TOKEN + VERCEL_PROJECT_ID
+# secrets (same pair used by deploy-watchdog.yml). Auto-skips with a
+# warning when those are missing.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+concurrency:
+  group: persona-walk-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  persona-walk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+
+      - name: Compute affected routes
+        id: routes
+        run: |
+          ROUTES=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
+            | node .github/scripts/affected-routes.mjs)
+          echo "routes=$ROUTES" >> "$GITHUB_OUTPUT"
+          if [ -z "$ROUTES" ]; then
+            echo "::notice::No rider-facing surfaces touched — skipping persona walk."
+            echo "skipped=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for Vercel preview
+        id: vercel
+        if: steps.routes.outputs.skipped != '1'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "::warning::VERCEL_TOKEN/VERCEL_PROJECT_ID not set — skipping persona walk."
+            echo "skipped=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          for i in $(seq 1 24); do
+            RESP=$(curl -fsS -H "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&meta-githubCommitSha=$SHA&limit=1" || true)
+            STATE=$(echo "$RESP" | jq -r '.deployments[0].state // ""')
+            URL=$(echo "$RESP" | jq -r '.deployments[0].url // ""')
+            echo "[try $i] state=$STATE url=$URL"
+            if [ "$STATE" = "READY" ] && [ -n "$URL" ]; then
+              echo "preview=https://$URL" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Vercel preview did not reach READY within 6 min."
+          exit 1
+
+      - name: Install tests/visual deps
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        working-directory: tests/visual
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Playwright browsers
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        working-directory: tests/visual
+        run: npx playwright install --with-deps chromium
+
+      - name: Run focused persona walks
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        working-directory: tests/visual
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY set — running --no-review."
+            REVIEW_FLAGS="--no-review"
+          else
+            REVIEW_FLAGS=""
+          fi
+          STAMP="pr-${{ github.event.pull_request.number }}-$(date +%s)"
+          echo "stamp=$STAMP" >> "$GITHUB_ENV"
+          for p in sport-bike-rider skeptic lurker; do
+            echo "=== persona: $p ==="
+            npx tsx personas/run-walk.ts \
+              --persona "$p" \
+              --base-url "${{ steps.vercel.outputs.preview }}" \
+              --routes "${{ steps.routes.outputs.routes }}" \
+              --stamp "$STAMP" \
+              $REVIEW_FLAGS
+          done
+
+      - name: Aggregate consensus
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        working-directory: tests/visual
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          SWEEP="out/persona-walks/$stamp"
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "# Consensus skipped (no auth)" > "$SWEEP/consensus.md"
+            echo "Per-route reviews captured but no LLM call made." >> "$SWEEP/consensus.md"
+          else
+            npx tsx personas/aggregate-consensus.ts --sweep-dir "$SWEEP"
+          fi
+
+      - name: Upload sweep artifact
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: persona-walk-pr-${{ github.event.pull_request.number }}
+          path: tests/visual/out/persona-walks/${{ env.stamp }}
+          retention-days: 14
+
+      - name: Post PR comment
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        uses: actions/github-script@v7
+        env:
+          PREVIEW: ${{ steps.vercel.outputs.preview }}
+          ROUTES: ${{ steps.routes.outputs.routes }}
+        with:
+          script: |
+            const fs = require('fs');
+            const p = `tests/visual/out/persona-walks/${process.env.stamp}/consensus.md`;
+            const head = `## Persona walk on Vercel preview\n\n**Preview:** ${process.env.PREVIEW}\n**Routes:** \`${process.env.ROUTES}\`\n**Personas:** sport-bike-rider, skeptic, lurker\n\n---\n\n`;
+            const tail = `\n\n_Full sweep + screenshots: workflow artifacts._`;
+            const body = head + (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '_consensus.md missing._') + tail;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## Summary

P20 Phase 1. On every PR open/synchronize, run a focused persona walk against the Vercel preview deploy. Three personas (sport-bike-rider, skeptic, lurker) × routes inferred from the PR's changed files. Posts a single PR comment with the consensus aggregator output.

## Required secrets (operator action before this is useful)

| Secret | Source | Purpose |
|---|---|---|
| `VERCEL_TOKEN` | Vercel dashboard → tokens | Poll deployments API for the PR commit's preview |
| `VERCEL_PROJECT_ID` | Vercel project settings | Filter the API query |
| `CLAUDE_CODE_OAUTH_TOKEN` *(preferred)* | Run `claude setup-token` locally | Subscription-billed `claude --print` |
| `ANTHROPIC_API_KEY` *(fallback)* | api.anthropic.com | API-billed |

If `VERCEL_TOKEN`/`VERCEL_PROJECT_ID` are missing, the workflow noops with a warning (no failure). If both Claude auth secrets are missing, the walk runs in `--no-review` mode (capture-only — screenshots + DOM, no LLM review).

## Affected-route mapping

`.github/scripts/affected-routes.mjs`:
- `app/(tabs)/<X>/page.tsx` → \`/X\`
- `components/*.tsx`, `lib/*`, `app/api/*`, `app/layout.tsx` → all routes (broad)
- everything else → no walk (skipped)

## Outputs

- Workflow artifact (14d retention) with screenshots + per-route reviews
- Single PR comment with `consensus.md` inline

## Test plan

- [x] `node .github/scripts/affected-routes.mjs` smoke test passes for several path shapes
- [x] YAML valid
- [x] Workflow path-allowlisted (`.github/`, `tests/visual/`, `scripts/`)
- [ ] CI build gate
- [ ] **Manual after merge:** open a draft PR touching `app/(tabs)/forecast/page.tsx` and confirm the workflow runs and posts a comment within 10 min

## Lines

208 (52 mapper + 156 workflow). 8 over the soft 200-line budget — the workflow's `if` guards on each step are the main contributor; trimming further would mask failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)