### PR TITLE
feat(ci): nightly full persona-walk sweep against prod

### DIFF
--- a/.github/workflows/persona-walk-nightly.yml
+++ b/.github/workflows/persona-walk-nightly.yml
@@ -1,0 +1,109 @@
+name: Persona walk nightly
+
+# Nightly full sweep against https://smokysignal.app — all 8 personas
+# × all 8 routes. Output: workflow artifact (90d retention) with the
+# screenshots, per-route reviews, and consensus.md. Phase 5 reads the
+# latest artifact to detect new high-signal findings vs prior nights.
+#
+# Cron: 04:00 PT (11:00 UTC) — runs after the prod cron snapshot/hot-
+# zone refresh has settled.
+#
+# Auth: same secrets as the per-PR walk (CLAUDE_CODE_OAUTH_TOKEN
+# preferred, ANTHROPIC_API_KEY fallback). If neither is set the sweep
+# runs in --no-review mode (capture-only) — still useful for seeing
+# regressions in chrome but not for the consensus pass.
+
+on:
+  schedule:
+    - cron: "0 11 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: persona-walk-nightly
+  cancel-in-progress: false
+
+jobs:
+  nightly-sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+
+      - name: Install tests/visual deps
+        working-directory: tests/visual
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Playwright browsers
+        working-directory: tests/visual
+        run: npx playwright install --with-deps chromium
+
+      - name: Run full sweep against prod
+        working-directory: tests/visual
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          STAMP="nightly-$(date -u +%Y-%m-%d)"
+          echo "stamp=$STAMP" >> "$GITHUB_ENV"
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning::No Claude auth secret set — running --no-review."
+            FLAGS="--no-review"
+          else
+            FLAGS=""
+          fi
+          for p in sport-bike-rider weekend-driver skeptic out-of-tz-onlooker operator lurker local-journalist off-duty-trooper; do
+            echo "=== persona: $p ==="
+            npx tsx personas/run-walk.ts \
+              --persona "$p" \
+              --base-url "https://smokysignal.app" \
+              --stamp "$STAMP" \
+              $FLAGS
+          done
+
+      - name: Aggregate consensus
+        working-directory: tests/visual
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          SWEEP="out/persona-walks/$stamp"
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "# Consensus skipped (no auth)" > "$SWEEP/consensus.md"
+          else
+            npx tsx personas/aggregate-consensus.ts --sweep-dir "$SWEEP"
+          fi
+
+      - name: Build findings.json (machine-readable summary)
+        working-directory: tests/visual
+        run: |
+          SWEEP="out/persona-walks/$stamp"
+          # Extract bullet items from the High-signal section. Crude but
+          # stable — Phase 5's findings-to-issues script normalizes them
+          # into a structured list.
+          node -e "
+            const fs = require('node:fs');
+            const md = fs.readFileSync('$SWEEP/consensus.md', 'utf8');
+            const m = /## High-signal findings[^\n]*\n+([\s\S]*?)\n## /m.exec(md);
+            const items = [];
+            if (m) {
+              for (const line of m[1].split('\n')) {
+                const t = line.replace(/^- /, '').trim();
+                if (t.length > 10) items.push(t);
+              }
+            }
+            fs.writeFileSync('$SWEEP/findings.json', JSON.stringify({stamp:'$stamp',items}, null, 2));
+            console.log('findings:', items.length);
+          "
+
+      - name: Upload sweep artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: persona-walk-${{ env.stamp }}
+          path: tests/visual/out/persona-walks/${{ env.stamp }}
+          retention-days: 90


### PR DESCRIPTION
## Summary

P20 Phase 2. Cron-triggered nightly at 04:00 PT, runs all 8 personas × all 8 routes against \`https://smokysignal.app\`, aggregates consensus, uploads a 90-day artifact.

## Output

- Sweep artifact: \`tests/visual/out/persona-walks/nightly-{YYYY-MM-DD}/\`
- \`consensus.md\` (Sonnet aggregator output)
- \`findings.json\` (machine-readable bullet items extracted from the High-signal section — for Phase 5 to read)

## Auth + skip behavior

Mirrors Phase 1:
- \`CLAUDE_CODE_OAUTH_TOKEN\` — subscription, preferred
- \`ANTHROPIC_API_KEY\` — API-key fallback
- Neither set → \`--no-review\` (capture-only, still usable for visual regression checks)

## Test plan

- [x] YAML valid
- [x] Path-allowlisted (\`.github/\` only)
- [ ] CI build gate
- [ ] **Manual after merge:** trigger via \`workflow_dispatch\` and confirm the sweep completes within 60 min and uploads the artifact

## Lines

109 — within the ≤200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)