### PR TITLE
docs(p20): document the continuous testing pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,41 @@ Audience: Puget Sound motorcyclists. Brand voice: dark theme, mono numerics,
   `use context7` to the prompt. Context7 fetches current docs into the
   model's context — beats relying on training-cutoff knowledge.
 
+### Continuous testing surfaces (P20 wired)
+
+Four GitHub Actions / spec layers run in addition to `npm run verify-prod`:
+
+- **Voice gate** (`.github/workflows/voice-gate.yml`) — every PR. Pure
+  regex/wordlist (no LLM, no auth) checking rider-facing copy against
+  `design/BRAND.md` §3+§8. Fails on banned vocab, emoji, exclamation
+  marks. Posts P1 nudges as a comment. Source of truth: the rule lists
+  in `.github/scripts/voice-gate.mjs`.
+- **PR persona walks** (`.github/workflows/persona-walk-pr.yml`) —
+  every PR with rider-facing changes. Walks 3 personas (sport-bike-rider,
+  skeptic, lurker) × routes inferred from the diff against the Vercel
+  preview URL. Posts a single PR comment with the consensus. Requires
+  `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` secrets and one of
+  `CLAUDE_CODE_OAUTH_TOKEN` (subscription, preferred) /
+  `ANTHROPIC_API_KEY`. Auto-skips with a warning when secrets missing.
+- **Nightly persona sweep** (`.github/workflows/persona-walk-nightly.yml`)
+  — cron 04:00 PT. Full 8-personas × 8-routes sweep against prod,
+  uploads 90-day artifact with `consensus.md` + `findings.json`.
+- **Findings → issues** (`.github/scripts/findings-to-issues.mjs`,
+  invoked at the end of the nightly workflow) — opens one GitHub issue
+  per high-signal finding (≥3 personas, no matching open issue).
+  Auto-labels by category.
+
+Behavioral persona walks (`tests/visual/personas/behavioral-walks.spec.ts`)
+exercise act-and-observe goals (tap, scroll, navigate) and emit a
+JSON action log per (persona, route). Run alongside the static specs.
+
+### Mock state machine
+
+`?mock=<state>` query param drives reproducible UI states for QA and
+persona walks. States: `up`, `down`, `eyes-up`, `multiple`, `stale`.
+Source: `lib/mock-state.ts`. Use these to validate copy/UX without
+waiting for a live event.
+
 ## Architecture quick-reference
 
 - `lib/snapshot.ts` — fleet snapshot from adsb.fi (primary) + OpenSky (fallback)

--- a/tests/visual/personas/README.md
+++ b/tests/visual/personas/README.md
@@ -150,13 +150,48 @@ the persona, escalate to `--model claude-sonnet-4-6`.
 The current Haiku id is `claude-haiku-4-5`. Bump the `DEFAULT_MODEL` constant
 in `run-walk.ts` when a newer Haiku ships.
 
+## How this fits the continuous testing pipeline (P20)
+
+This script is the inner loop. The outer loops are:
+
+| Surface | Fires when | Output |
+|---|---|---|
+| `npm run verify-prod` | manual / pre-push | `/tmp/p14-audit/findings.json` + screenshots |
+| `.github/workflows/voice-gate.yml` | every PR | PR comment (P0 violations block merge) |
+| `.github/workflows/persona-walk-pr.yml` | every PR with rider-facing changes | PR comment with consensus + 14d artifact |
+| `.github/workflows/persona-walk-nightly.yml` | cron 04:00 PT | 90d artifact + auto-issues for new high-signal findings |
+| `tests/visual/personas/behavioral-walks.spec.ts` | runs alongside static walks | per-(persona,route) JSON action log |
+
+The `aggregate-consensus.ts` sibling reads any sweep dir produced by
+`run-walk.ts` and emits `consensus.md` via Sonnet. Both the per-PR
+workflow and the nightly workflow call it.
+
+`findings-to-issues.mjs` reads the nightly `findings.json` and opens
+GitHub issues for new high-signal items (≥3 personas, no duplicate
+title). Auto-labels by category.
+
+## Mock state machine
+
+Use `?mock=<state>` on rider-facing pages to drive deterministic UI
+states for QA:
+
+| Param | Effect |
+|---|---|
+| `?mock=up` | ≥1 smokey airborne |
+| `?mock=down` | All grounded |
+| `?mock=eyes-up` | Patrol/unknown airborne, no smokey |
+| `?mock=multiple` | 3 smokeys + 1 patrol airborne |
+| `?mock=stale` | Last sample 16 min ago (FreshnessLabel amber) |
+
+Source of truth: `lib/mock-state.ts`. Persona-walk specs use these
+states to exercise specific UI variants.
+
 ## What's deliberately not here yet
 
-- **CI / GitHub Action wiring** — Phase 3.
 - **iOS Simulator integration** — gated on the new Mac landing.
-- **Sonnet consensus pass invocation from this script** — Phase 4 lives in a
-  sibling aggregator script.
-- **Real-user feedback loop** into persona evolution — Phase 5.
+- **Visual regression / screenshot diff** — separate prompt.
+- **Performance budget tracking** — separate prompt.
+- **Real-user feedback loop** into persona evolution — separate prompt.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

Closes out P20. Two doc updates:

- **CLAUDE.md** — adds a "Continuous testing surfaces" subsection under "Verification habits" that references the four CI layers wired in P20 (voice gate, PR persona walks, nightly sweep, findings → issues) plus the mock state machine.

- **tests/visual/personas/README.md** — adds a "How this fits the continuous testing pipeline" table mapping each outer-loop surface to its trigger and output, plus a section documenting the \`?mock=<state>\` machine.

## verify-prod after all P20 PRs deployed

- 16 passed / 1 failed
- All 7 P19/P20 assertions PASS:
  - LEARNING THE SKY rendered, "YOUR SKY" absent
  - /plane/[tail] no "last seen" duplicate
  - Home FreshnessLabel includes HH:MM PT
  - /activity rows have HH:MM PT
  - /forecast bridge correctly absent (no alert-class plane currently airborne)
  - ?mock=eyes-up returns patrol airborne, no smokey
  - ?mock=stale returns fetched_at >15min ago
- Single failure (#10 hot-zones-filter terminology) is the **pre-existing** IOSInstallPrompt click intercept — unrelated to P20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)