### PR TITLE
fix(ios-install-prompt): pointer-events: none on dialog wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,41 @@ Audience: Puget Sound motorcyclists. Brand voice: dark theme, mono numerics,
   `use context7` to the prompt. Context7 fetches current docs into the
   model's context — beats relying on training-cutoff knowledge.
 
+### Continuous testing surfaces (P20 wired)
+
+Four GitHub Actions / spec layers run in addition to `npm run verify-prod`:
+
+- **Voice gate** (`.github/workflows/voice-gate.yml`) — every PR. Pure
+  regex/wordlist (no LLM, no auth) checking rider-facing copy against
+  `design/BRAND.md` §3+§8. Fails on banned vocab, emoji, exclamation
+  marks. Posts P1 nudges as a comment. Source of truth: the rule lists
+  in `.github/scripts/voice-gate.mjs`.
+- **PR persona walks** (`.github/workflows/persona-walk-pr.yml`) —
+  every PR with rider-facing changes. Walks 3 personas (sport-bike-rider,
+  skeptic, lurker) × routes inferred from the diff against the Vercel
+  preview URL. Posts a single PR comment with the consensus. Requires
+  `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` secrets and one of
+  `CLAUDE_CODE_OAUTH_TOKEN` (subscription, preferred) /
+  `ANTHROPIC_API_KEY`. Auto-skips with a warning when secrets missing.
+- **Nightly persona sweep** (`.github/workflows/persona-walk-nightly.yml`)
+  — cron 04:00 PT. Full 8-personas × 8-routes sweep against prod,
+  uploads 90-day artifact with `consensus.md` + `findings.json`.
+- **Findings → issues** (`.github/scripts/findings-to-issues.mjs`,
+  invoked at the end of the nightly workflow) — opens one GitHub issue
+  per high-signal finding (≥3 personas, no matching open issue).
+  Auto-labels by category.
+
+Behavioral persona walks (`tests/visual/personas/behavioral-walks.spec.ts`)
+exercise act-and-observe goals (tap, scroll, navigate) and emit a
+JSON action log per (persona, route). Run alongside the static specs.
+
+### Mock state machine
+
+`?mock=<state>` query param drives reproducible UI states for QA and
+persona walks. States: `up`, `down`, `eyes-up`, `multiple`, `stale`.
+Source: `lib/mock-state.ts`. Use these to validate copy/UX without
+waiting for a live event.
+
 ## Architecture quick-reference
 
 - `lib/snapshot.ts` — fleet snapshot from adsb.fi (primary) + OpenSky (fallback)

--- a/components/IOSInstallPrompt.tsx
+++ b/components/IOSInstallPrompt.tsx
@@ -119,12 +119,20 @@ export function IOSInstallPrompt() {
   return (
     <div
       role="dialog"
+      // pointer-events: none on the wrapper so the prompt doesn't intercept
+      // taps meant for the map / filter button on /radar. Interactive children
+      // opt back in via pointerEvents: "auto". Instruction text stays
+      // visible (the wrapper is still painted) but isn't tappable — taps on
+      // text fall through to the radar layer underneath. The X button + the
+      // post-install "Arm alerts" link are the only tap targets inside the
+      // prompt. Fixes verify-prod #10 (hot-zones filter click intercept).
       style={{
         position: "fixed",
         left: 0,
         right: 0,
         bottom: bottomOffset,
         zIndex: 40,
+        pointerEvents: "none",
         padding: "12px 14px calc(12px + env(safe-area-inset-bottom))",
         background: SS_TOKENS.bg1,
         borderTop: `.5px solid ${SS_TOKENS.hairline}`,
@@ -159,6 +167,7 @@ export function IOSInstallPrompt() {
           justifyContent: "center",
           flexShrink: 0,
           padding: 0,
+          pointerEvents: "auto",
         }}
       >
         <XIcon />
@@ -217,6 +226,7 @@ function PostInstallCopy({ pulse }: { pulse: boolean }) {
           fontWeight: 600,
           textDecoration: "none",
           animation: pulse ? "ss-arm-alerts-pulse 1.6s ease-out 3" : undefined,
+          pointerEvents: "auto",
         }}
       >
         Arm alerts

--- a/tests/visual/personas/README.md
+++ b/tests/visual/personas/README.md
@@ -150,13 +150,48 @@ the persona, escalate to `--model claude-sonnet-4-6`.
 The current Haiku id is `claude-haiku-4-5`. Bump the `DEFAULT_MODEL` constant
 in `run-walk.ts` when a newer Haiku ships.
 
+## How this fits the continuous testing pipeline (P20)
+
+This script is the inner loop. The outer loops are:
+
+| Surface | Fires when | Output |
+|---|---|---|
+| `npm run verify-prod` | manual / pre-push | `/tmp/p14-audit/findings.json` + screenshots |
+| `.github/workflows/voice-gate.yml` | every PR | PR comment (P0 violations block merge) |
+| `.github/workflows/persona-walk-pr.yml` | every PR with rider-facing changes | PR comment with consensus + 14d artifact |
+| `.github/workflows/persona-walk-nightly.yml` | cron 04:00 PT | 90d artifact + auto-issues for new high-signal findings |
+| `tests/visual/personas/behavioral-walks.spec.ts` | runs alongside static walks | per-(persona,route) JSON action log |
+
+The `aggregate-consensus.ts` sibling reads any sweep dir produced by
+`run-walk.ts` and emits `consensus.md` via Sonnet. Both the per-PR
+workflow and the nightly workflow call it.
+
+`findings-to-issues.mjs` reads the nightly `findings.json` and opens
+GitHub issues for new high-signal items (≥3 personas, no duplicate
+title). Auto-labels by category.
+
+## Mock state machine
+
+Use `?mock=<state>` on rider-facing pages to drive deterministic UI
+states for QA:
+
+| Param | Effect |
+|---|---|
+| `?mock=up` | ≥1 smokey airborne |
+| `?mock=down` | All grounded |
+| `?mock=eyes-up` | Patrol/unknown airborne, no smokey |
+| `?mock=multiple` | 3 smokeys + 1 patrol airborne |
+| `?mock=stale` | Last sample 16 min ago (FreshnessLabel amber) |
+
+Source of truth: `lib/mock-state.ts`. Persona-walk specs use these
+states to exercise specific UI variants.
+
 ## What's deliberately not here yet
 
-- **CI / GitHub Action wiring** — Phase 3.
 - **iOS Simulator integration** — gated on the new Mac landing.
-- **Sonnet consensus pass invocation from this script** — Phase 4 lives in a
-  sibling aggregator script.
-- **Real-user feedback loop** into persona evolution — Phase 5.
+- **Visual regression / screenshot diff** — separate prompt.
+- **Performance budget tracking** — separate prompt.
+- **Real-user feedback loop** into persona evolution — separate prompt.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

P21 Phase 1. verify-prod #10 (hot-zones filter terminology) has been failing for several sweeps because the IOSInstallPrompt's \`role=\"dialog\"\` overlay covers the bottom edge of \`/radar\` — including the filter button — and Playwright's actionability check correctly reports the click intercept. Real iOS users hit the same issue.

## Fix

Per the user-spec preferred path (option 1):
- \`pointer-events: none\` on the dialog wrapper
- \`pointer-events: auto\` on the dismiss X button
- \`pointer-events: auto\` on the post-install "Arm alerts" Link

Instruction text stays visible but isn't tappable — taps on text fall through to the underlying radar/filter layer. Tap targets that should remain interactive (dismiss + Arm alerts CTA) keep working.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [ ] CI build gate
- [ ] **Manual after merge:** verify-prod #10 flips to PASS; #9 still PASSES (the prompt is still rendered + visible, just not event-blocking)

## Lines

10-line diff to \`components/IOSInstallPrompt.tsx\`. Way under the ≤200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)