### PR TITLE
feat(mock): ?mock=learning + ?mock=full-data data-layer overrides

### DIFF
--- a/app/(tabs)/forecast/page.tsx
+++ b/app/(tabs)/forecast/page.tsx
@@ -8,6 +8,12 @@ import { getTimeFormatPref, isHour12 } from "@/lib/user-prefs";
 import { getSnapshot } from "@/lib/snapshot";
 import { getRegistry } from "@/lib/registry";
 import { computeStatus } from "@/lib/status";
+import {
+  applyMockForecastGrid,
+  applyMockLearning,
+  applyMockState,
+  parseMockState,
+} from "@/lib/mock-state";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -17,13 +23,23 @@ export const metadata = {
 
 const FORECAST_LEARNING_EVENT_FLOOR = 30;
 
-export default async function ForecastPage() {
-  const [grid, learning, snap, fleet] = await Promise.all([
+type SP = { mock?: string };
+
+export default async function ForecastPage({
+  searchParams,
+}: {
+  searchParams: SP;
+}) {
+  const mockState = parseMockState(searchParams.mock);
+  const [realGrid, realLearning, realSnap, fleet] = await Promise.all([
     getForecastGrid(),
     getLearningState(),
     getSnapshot(),
     getRegistry(),
   ]);
+  const grid = applyMockForecastGrid(realGrid, mockState);
+  const learning = applyMockLearning(realLearning, mockState);
+  const snap = applyMockState(realSnap, mockState);
   const fleetMap = new Map(fleet.map((f) => [f.tail, f]));
   const liveStatus = computeStatus(snap, fleetMap);
   const showLearning =

--- a/lib/mock-state.ts
+++ b/lib/mock-state.ts
@@ -2,13 +2,13 @@
 // routes. Deterministic — same query param yields the same response
 // shape, no randomness, no time-of-day drift.
 //
-// Snapshot-level states (this file): up, down, eyes-up, multiple, stale.
-//
-// Data-layer states (deferred to a follow-up): learning, full-data —
-// those need overrides in lib/learning.ts and lib/predictor.ts. Tracking
-// in the issue queue.
+// Snapshot-level states: up, down, eyes-up, multiple, stale.
+// Data-layer states: learning (forecast empty + Day 0 of 30),
+// full-data (predictor confident + learning panel hidden).
 
 import type { Snapshot, FleetRole } from "./types";
+import type { LearningState } from "./learning";
+import type { ForecastGrid, ForecastCell } from "./predictor";
 
 export const MOCK_STATES = [
   "up",
@@ -16,6 +16,8 @@ export const MOCK_STATES = [
   "eyes-up",
   "multiple",
   "stale",
+  "learning",
+  "full-data",
 ] as const;
 export type MockState = (typeof MOCK_STATES)[number];
 
@@ -118,5 +120,81 @@ export function applyMockState(snap: Snapshot, state: MockState | null): Snapsho
         source: "mock",
         fetched_at: Date.now() - 16 * 60 * 1000,
       };
+    case "learning":
+    case "full-data":
+      // These two states are data-layer (forecast/learning), not
+      // snapshot-level. Fall through to the dedicated transformers
+      // (applyMockLearning, applyMockForecastGrid). Snapshot itself
+      // unchanged.
+      return snap;
   }
+}
+
+/** LearningState override for ?mock=learning / ?mock=full-data. */
+export function applyMockLearning(
+  real: LearningState,
+  state: MockState | null,
+): LearningState {
+  if (state === "learning") {
+    return {
+      firstSampleIso: new Date().toISOString(),
+      daysElapsed: 0,
+      daysRemaining: 30,
+      progress: 0,
+      stillLearning: true,
+    };
+  }
+  if (state === "full-data") {
+    return {
+      firstSampleIso: new Date(Date.now() - 31 * 86_400_000).toISOString(),
+      daysElapsed: 31,
+      daysRemaining: 0,
+      progress: 1,
+      stillLearning: false,
+    };
+  }
+  return real;
+}
+
+/**
+ * ForecastGrid override. Learning state returns empty cells; full-data
+ * synthesizes a deterministic 7×24 grid with realistic-looking commute-
+ * shaped probabilities (peaks Mon–Fri 7–9 / 16–18 PT, lower weekends).
+ */
+export function applyMockForecastGrid(
+  real: ForecastGrid,
+  state: MockState | null,
+): ForecastGrid {
+  if (state === "learning") {
+    return { cells: [], total_events: 0, generated_at: Date.now() };
+  }
+  if (state === "full-data") {
+    const cells: ForecastCell[] = [];
+    let total = 0;
+    for (let dow = 0; dow < 7; dow++) {
+      const weekday = dow >= 1 && dow <= 5;
+      for (let hour = 0; hour < 24; hour++) {
+        const commute =
+          weekday &&
+          ((hour >= 7 && hour <= 9) || (hour >= 16 && hour <= 18));
+        const base = commute ? 0.55 : weekday ? 0.18 : 0.12;
+        // Smooth daily curve so the heatmap looks plausible; deterministic.
+        const wave = 0.08 * Math.sin(((hour - 6) * Math.PI) / 12);
+        const probability = Math.max(0, Math.min(1, base + wave));
+        const sample_count = Math.round(probability * 22);
+        total += sample_count;
+        cells.push({
+          dow,
+          hour,
+          probability,
+          sample_count,
+          common_tails: [
+            { tail: "N305DK", nickname: "Smokey 4", count: sample_count },
+          ],
+        });
+      }
+    }
+    return { cells, total_events: total, generated_at: Date.now() };
+  }
+  return real;
 }

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -586,4 +586,50 @@ test.describe("p14 live-prod audit", () => {
       evidence,
     });
   });
+
+  test("17. ?mock=learning shows the learning panel on /forecast (P21 2.1)", async ({
+    page,
+  }) => {
+    await page.goto("/forecast?mock=learning", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "17-forecast-mock-learning");
+    const html = (await page.content()).toUpperCase();
+    const hasLearning = html.includes("LEARNING THE SKY");
+    const hasDay0 = /DAY 0 OF 30/.test(html);
+    const pass = hasLearning && hasDay0;
+    record({
+      claim:
+        "?mock=learning forces /forecast into Day 0 of 30 — learning panel visible",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? '"LEARNING THE SKY" + "DAY 0 OF 30" both rendered'
+        : `learning=${hasLearning} day0=${hasDay0}`,
+      screenshot,
+    });
+  });
+
+  test("18. ?mock=full-data hides the learning panel on /forecast (P21 2.2)", async ({
+    page,
+  }) => {
+    await page.goto("/forecast?mock=full-data", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+    const screenshot = await shot(page, "18-forecast-mock-full-data");
+    const html = (await page.content()).toUpperCase();
+    // In full-data state, the synthesized grid has plenty of events and
+    // learning.stillLearning is false → LearningPanel renders nothing
+    // (showLearning gate fails) and the eyebrow is absent.
+    const hasLearning = html.includes("LEARNING THE SKY");
+    const pass = !hasLearning;
+    record({
+      claim:
+        "?mock=full-data hides the LearningPanel on /forecast — predictor confident, no learning eyebrow",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: pass
+        ? "learning panel absent (eyebrow not rendered)"
+        : "learning panel still rendered with full-data — gate didn't trip",
+      screenshot,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P21 Phase 2. Completes the deferred mock states from P20. Unlocks behavioral persona walks against the two "extreme" data states (no data yet vs plenty of data).

| Param | Behavior |
|---|---|
| \`?mock=learning\` | \`daysElapsed=0, daysRemaining=30, stillLearning=true\`; forecast cells empty; LearningPanel visible with "Day 0 of 30" |
| \`?mock=full-data\` | \`daysElapsed=31, stillLearning=false\`; deterministic 7×24 grid with commute-shaped probabilities; LearningPanel hidden |

## Implementation

Two new transformers in \`lib/mock-state.ts\`: \`applyMockLearning\`, \`applyMockForecastGrid\`. Wired into \`/forecast/page.tsx\`. Both deterministic — same query param yields identical response.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertions #17 + #18 added
- [ ] CI build gate
- [ ] **Manual after merge:** hit \`https://smokysignal.app/forecast?mock=learning\` and confirm "LEARNING THE SKY · DAY 0 OF 30" visible; \`?mock=full-data\` and confirm learning panel absent

## Lines

147 added / 7 deleted — within the ≤200 budget.

## Out of scope

Hot-zones overrides for these states (radar map). The forecast / learning panel are the load-bearing surfaces for the persona-walk use case; if a future behavioral walk needs synthesized hot zones for full-data, file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)