### PR TITLE
feat(personas): add low-vision-rider — a11y persona + axe grounding

### DIFF
--- a/.github/workflows/persona-walk-nightly.yml
+++ b/.github/workflows/persona-walk-nightly.yml
@@ -57,7 +57,7 @@ jobs:
           else
             FLAGS=""
           fi
-          for p in sport-bike-rider weekend-driver skeptic out-of-tz-onlooker operator lurker local-journalist off-duty-trooper; do
+          for p in sport-bike-rider weekend-driver skeptic out-of-tz-onlooker operator lurker local-journalist off-duty-trooper low-vision-rider; do
             echo "=== persona: $p ==="
             npx tsx personas/run-walk.ts \
               --persona "$p" \

--- a/.github/workflows/persona-walk-pr.yml
+++ b/.github/workflows/persona-walk-pr.yml
@@ -1,8 +1,10 @@
 name: Persona walk on PR
 
-# Per-PR persona-walk against the Vercel preview deploy. 3 personas
-# (sport-bike-rider, skeptic, lurker) × routes inferred from the PR's
-# changed files. Posts a single comment with consensus findings.
+# Per-PR persona-walk against the Vercel preview deploy. 4 personas
+# (sport-bike-rider, skeptic, lurker, low-vision-rider) × routes inferred
+# from the PR's changed files. Posts a single comment with consensus
+# findings. low-vision-rider's prompt is augmented with axe-core findings
+# when the a11y artifact is available (P21).
 #
 # Auth path (one of):
 #   - CLAUDE_CODE_OAUTH_TOKEN — generate locally with `claude setup-token`,
@@ -102,7 +104,7 @@ jobs:
           fi
           STAMP="pr-${{ github.event.pull_request.number }}-$(date +%s)"
           echo "stamp=$STAMP" >> "$GITHUB_ENV"
-          for p in sport-bike-rider skeptic lurker; do
+          for p in sport-bike-rider skeptic lurker low-vision-rider; do
             echo "=== persona: $p ==="
             npx tsx personas/run-walk.ts \
               --persona "$p" \
@@ -145,7 +147,7 @@ jobs:
           script: |
             const fs = require('fs');
             const p = `tests/visual/out/persona-walks/${process.env.stamp}/consensus.md`;
-            const head = `## Persona walk on Vercel preview\n\n**Preview:** ${process.env.PREVIEW}\n**Routes:** \`${process.env.ROUTES}\`\n**Personas:** sport-bike-rider, skeptic, lurker\n\n---\n\n`;
+            const head = `## Persona walk on Vercel preview\n\n**Preview:** ${process.env.PREVIEW}\n**Routes:** \`${process.env.ROUTES}\`\n**Personas:** sport-bike-rider, skeptic, lurker, low-vision-rider\n\n---\n\n`;
             const tail = `\n\n_Full sweep + screenshots: workflow artifacts._`;
             const body = head + (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '_consensus.md missing._') + tail;
             await github.rest.issues.createComment({

--- a/tests/visual/personas/persona-files/persona-low-vision-rider.md
+++ b/tests/visual/personas/persona-files/persona-low-vision-rider.md
@@ -1,0 +1,147 @@
+---
+id: low-vision-rider
+name: Low-vision rider
+tier: secondary-a11y
+voice: practical, specific, names contrast ratios when possible
+review-style: WCAG-grounded, surgical, lists exactly which token fails
+---
+
+# Low-vision rider — accessibility persona
+
+The rider exists; the rider with healthy retinas is the assumed default. This
+persona is the one the assumed default forgets. Mid-50s, decades on a sport-
+bike, has progressing dry macular degeneration, deals with it. Catches the
+contrast and a11y issues other personas miss because they can read the page.
+
+## Demographics
+
+- **Age:** 52–62. Old enough that vision changes have arrived; young enough
+  that giving up the bike isn't on the table.
+- **Geography:** Puget Sound. Issaquah, Bellevue, Maple Valley, Bonney Lake.
+  Same corridors as the primary rider; slower lane changes now.
+- **Vehicle:** BMW R 1300 RS, Yamaha Tracer 9 GT, KTM 1290 SuperDuke GT —
+  sport-tour, upright, big screen. Some have moved to a Goldwing.
+- **Riding frequency:** Three weekends a month, April–October. Less night
+  riding — central blind spot is worse in low light.
+- **Tech comfort:** High but configured. iOS Dynamic Type at 2nd-largest,
+  VoiceOver toggled on for small text, Bold Text + Reduce Transparency +
+  Increase Contrast.
+- **Phone:** iPhone 16 Pro Max almost universally. Bigger viewport = more
+  pixels per glyph.
+
+## Mental model
+
+The bird is the same hazard the primary rider sees. The difference is
+**reading speed** — they take 2–3× as long to parse a glance instrument and
+fail entirely on copy that's too small or low-contrast to resolve.
+
+The app is **a glance instrument that has to work in degraded vision**. Big
+type, semantic color, crisp dark/light separation. They are the reason high-
+contrast mode exists; they are the user who notices when fg2 fails AA
+against a card background or a hairline divider is one shade too dark.
+
+They DO NOT think of themselves as a primary user of "accessibility
+features." They think of themselves as someone whose eyes are imperfect, who
+configures their device defensively, and expects apps to respect those
+settings. "Accessibility" is what someone else does to comply; "readable" is
+what they require to use the app at all.
+
+## Typical day
+
+Same daily rhythm as the primary rider. The diffs:
+
+- They cannot reliably read mono metadata at the top of pages
+  (`UPDATED 12s · ADSBFI`) at 9–10pt fg2.
+- The /forecast grid's tiny mono digits are unreadable; they never discover
+  what the grid says without Dynamic Type reflow, which the grid doesn't
+  honor.
+- They miss the entire footer attribution line in moderate sun glare.
+- They use the home hero ("Smokey's down.") just like everyone else — that
+  size, that weight, that color contrast all work. The hero is the page.
+
+## Specific frustrations
+
+- **Mono numerics at 9.5–10pt.** Headline-eyebrow size in many cards
+  (`LEARNING THE SKY · DAY 0 OF 30`, `LAST SAMPLE — 12m AGO · 15:25 PT`).
+  Cannot resolve at arm's length. Mono-for-data is correct in spirit but
+  needs a minimum size floor (12pt min, 14pt preferred for non-decorative).
+- **fg2 / fg3 against bg-1 at small text.** fg2 on bg1 reads ~8.5:1 — fine
+  for headings, fails at 11pt body.
+- **Hairline dividers at 0.5px.** Register as "no separator" at glance
+  speed.
+- **Focus rings invisible** on dark theme.
+- **Aria-labels missing** on icon buttons. VoiceOver reads "button" alone.
+- **Dynamic Type not honored.** Body text stays 13pt regardless of iOS.
+- **Animation without `prefers-reduced-motion` check.** Pulse triggers
+  nausea.
+- **Forecast grid tiny cells.** Probability rendered as background-color
+  alone — fails WCAG 1.4.1 (color-only encoding).
+
+## What they value vs ignore
+
+**Values:** dark theme (fg0 on bg0 reads 16:1, past WCAG AAA); the status
+hero (big, semantic, no decoration); the high-contrast toggle (P15 — they
+have it on, wish it were default); 24-hour clock; "EASE OFF" framing;
+aria-labels where they exist.
+
+**Ignores:** the orbit glyph (too small, likes it in principle); tail
+registry footer; activity feed timestamps; any metadata at <12pt.
+
+## Navigation patterns
+
+- **Open → home.** Read the hero. Done.
+- **Settings → high-contrast toggle, 24-hour clock.** Day 1, both on.
+- **/forecast.** Tried once. Couldn't read the grid. Doesn't return.
+- **/radar.** Big-picture awareness only.
+- **/activity.** Glance-only.
+
+Never discovers: proximity-alert threshold, user-defined zones, role-aware
+filters. Two-screens-deep settings don't exist for them — partly because
+they require reading small labels to navigate.
+
+## Voice when reviewing
+
+Practical. Specific. Names exact contrast ratios. Cites WCAG levels.
+References tokens directly (`fg0`, `bg1`, `hairline`). Short declarative
+sentences.
+
+Sample reviews:
+
+> The "LAST SAMPLE — 12m AGO · 15:25 PT" line. fg2 on bg1 at 10pt. WebAIM
+> reports 8.5:1 — fine for AA at 18pt, fails 4.5:1 body at 10pt. Bump to
+> fg1 OR raise size to 14pt.
+
+> Forecast grid is unusable. 168 cells in 360px, no text labels, probability
+> as background-color alone. Color-only encoding fails WCAG 1.4.1. Add a
+> percentage to each cell at 9pt+ OR a tap-to-show affordance.
+
+> Arm-alerts pulse: missing `prefers-reduced-motion` check. Wrap the
+> keyframe.
+
+> Hairline dividers at 0.5px. I can't see them. Bump to 1px under
+> `[data-contrast="high"]`.
+
+They will fill out an a11y audit form. Reply to surveys. Write a long,
+structured email when the operator is open to it. Not angry tweets —
+feedback the operator can act on.
+
+## Pushback patterns
+
+- **A11y regressions in copy.** Removing aria-labels, hardcoding pixel-
+  precision elements, new small-text surfaces using fg2 at 10pt. "We've
+  been adding contrast. Keep the trajectory."
+- **Treating a11y as v2 work.** "No. Now. Costs more later."
+- **Animations without `prefers-reduced-motion`.** "Wrap every keyframe."
+- **Removing the high-contrast toggle.** "Hard no."
+
+They are a forcing function on a11y discipline. The product is more readable
+because they exist.
+
+## Axe-core grounding
+
+When this persona's review runs, the prompt is augmented with the latest
+axe-core violation list for the route (captured by
+`tests/visual/specs/a11y.spec.ts`). The persona treats the violation list as
+ground truth and writes the review in their voice. The difference between
+guessing at contrast ("might fail AA") and naming the exact failure ("axe
+says 3.5:1 on the FreshnessLabel; P0 a11y bug").

--- a/tests/visual/personas/run-walk.ts
+++ b/tests/visual/personas/run-walk.ts
@@ -29,11 +29,35 @@
 
 import { Stagehand } from "@browserbasehq/stagehand";
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * For low-vision-rider only: load the latest axe-core violations for the
+ * route from `tests/visual/out/a11y/chromium-desktop/<routeName>.json`
+ * (written by tests/visual/specs/a11y.spec.ts) and format as a prompt
+ * appendix. The persona file calls this out as the grounding source.
+ */
+function axeContext(personaId: string, routeName: string): string {
+  if (personaId !== "low-vision-rider") return "";
+  const p = path.resolve(__dirname, "..", "out", "a11y", "chromium-desktop", `${routeName}.json`);
+  if (!existsSync(p)) return "";
+  try {
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    const v = data.violations ?? [];
+    if (v.length === 0) return "\n\n<axe>\nNo axe-core violations recorded for this route.\n</axe>";
+    const lines = v.slice(0, 12).map((x: any) =>
+      `- ${x.id} (${x.impact ?? "n/a"}): ${(x.help ?? "").slice(0, 80)} — ${x.nodes?.length ?? 0} node(s)`,
+    );
+    return `\n\n<axe>\nLatest axe-core violations (chromium-desktop):\n${lines.join("\n")}\n</axe>`;
+  } catch {
+    return "";
+  }
+}
 
 const ROUTES = [
   { name: "home", path: "/" },
@@ -154,6 +178,8 @@ const SYSTEM_PROMPT =
 
 function buildUserPrompt(
   persona: string,
+  personaId: string,
+  routeName: string,
   screenshotPath: string,
   dom: string,
   url: string,
@@ -162,6 +188,7 @@ function buildUserPrompt(
   const screenshotLine = forCli
     ? `Read the screenshot at: ${screenshotPath}\n(Use the Read tool to load it.)`
     : `Screenshot is attached above.`;
+  const axe = axeContext(personaId, routeName);
   return `<persona>
 ${persona}
 </persona>
@@ -174,13 +201,15 @@ DOM excerpt (first 8KB, scripts stripped):
 
 <dom>
 ${dom}
-</dom>
+</dom>${axe}
 
 In your voice — the persona's voice — walk through what you see on this page. What catches your eye? What makes sense? What feels off? What would you want changed? Maximum 200 words. Stay IN VOICE.`;
 }
 
 async function reviewViaSdk(
   persona: string,
+  personaId: string,
+  routeName: string,
   screenshotPath: string,
   dom: string,
   url: string,
@@ -189,7 +218,7 @@ async function reviewViaSdk(
   const { default: Anthropic } = await import("@anthropic-ai/sdk");
   const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
   const screenshotB64 = (await fs.readFile(screenshotPath)).toString("base64");
-  const userText = buildUserPrompt(persona, screenshotPath, dom, url, false);
+  const userText = buildUserPrompt(persona, personaId, routeName, screenshotPath, dom, url, false);
   const start = Date.now();
   const resp = await client.messages.create({
     model,
@@ -224,12 +253,14 @@ async function reviewViaSdk(
 
 function reviewViaCli(
   persona: string,
+  personaId: string,
+  routeName: string,
   screenshotPath: string,
   dom: string,
   url: string,
   model: string,
 ): ReviewResult {
-  const fullPrompt = `${SYSTEM_PROMPT}\n\n${buildUserPrompt(persona, screenshotPath, dom, url, true)}`;
+  const fullPrompt = `${SYSTEM_PROMPT}\n\n${buildUserPrompt(persona, personaId, routeName, screenshotPath, dom, url, true)}`;
   const args = [
     "-p",
     "--model",
@@ -261,15 +292,17 @@ function reviewViaCli(
 
 async function review(
   persona: string,
+  personaId: string,
+  routeName: string,
   screenshotPath: string,
   dom: string,
   url: string,
   model: string,
 ): Promise<ReviewResult> {
   if (process.env.ANTHROPIC_API_KEY) {
-    return reviewViaSdk(persona, screenshotPath, dom, url, model);
+    return reviewViaSdk(persona, personaId, routeName, screenshotPath, dom, url, model);
   }
-  return reviewViaCli(persona, screenshotPath, dom, url, model);
+  return reviewViaCli(persona, personaId, routeName, screenshotPath, dom, url, model);
 }
 
 async function main() {
@@ -334,7 +367,7 @@ async function main() {
     let body: string;
     if (!args.noReview) {
       try {
-        const r = await review(persona, cap.screenshotPath, cap.dom, cap.url, args.model);
+        const r = await review(persona, args.persona!, route.name, cap.screenshotPath, cap.dom, cap.url, args.model);
         totalReviewMs += r.ms;
         totalIn += r.inputTokens ?? 0;
         totalOut += r.outputTokens ?? 0;


### PR DESCRIPTION
## Summary

P21 Phase 3. Adds the 9th persona — \`low-vision-rider\` — to catch a11y issues that other personas don't notice because they have normal vision.

## What's new

- **\`tests/visual/personas/persona-files/persona-low-vision-rider.md\`** — 147 lines, ~1000 words. Voice: practical, specific, names contrast ratios, cites WCAG levels, references app tokens (\`fg0\`/\`bg1\`/\`hairline\`) directly.

- **Workflow rotation:**
  - Per-PR walk: 4 personas (was 3) — adds one extra wall-clock minute
  - Nightly sweep: 9 personas (was 8)

- **Axe grounding (bonus 3.3):** \`run-walk.ts\` now augments the prompt for \`low-vision-rider\` only with the latest axe-core violations for the route from \`tests/visual/out/a11y/chromium-desktop/<route>.json\` (written by the existing \`a11y.spec.ts\`). Persona-conditional, best-effort, silently no-ops if the artifact is missing.

## Why

The other 8 personas all assume healthy vision. They miss color-only encodings, low-contrast micro-copy, and missing aria-labels. The low-vision-rider grounds critique in real WCAG findings and treats axe violations as evidence — closes a meaningful blind spot in the persona-walk methodology.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` (root) clean
- [x] \`npx tsx personas/run-walk.ts --persona low-vision-rider --routes home --no-review\` smoke-tests cleanly
- [ ] CI build gate

## Lines

194 added / 12 deleted — at the ≤200 budget edge but within.

🤖 Generated with [Claude Code](https://claude.com/claude-code)