### PR TITLE
feat(infra): Mac Mini heartbeat — hourly KV write + nightly staleness check

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -1,0 +1,40 @@
+name: Heartbeat
+
+# Hourly write of the current epoch-seconds to KV key meta:last_heartbeat.
+# /api/health surfaces it as last_heartbeat_iso + last_heartbeat_age_s.
+# The nightly persona-walk workflow checks freshness and opens an
+# infra-alert issue if the heartbeat is older than 90 minutes.
+#
+# Auto-skips with a warning when KV_REST_API_URL / KV_REST_API_TOKEN
+# secrets are not configured — same fail-soft pattern the rest of the
+# CI uses.
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: heartbeat
+  cancel-in-progress: false
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Write meta:last_heartbeat to KV
+        env:
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+        run: |
+          if [ -z "$KV_REST_API_URL" ] || [ -z "$KV_REST_API_TOKEN" ]; then
+            echo "::warning::KV_REST_API_URL/KV_REST_API_TOKEN not set — heartbeat noop."
+            exit 0
+          fi
+          NOW=$(date +%s)
+          # Upstash REST: POST .../set/<key>/<value>
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $KV_REST_API_TOKEN" \
+            "$KV_REST_API_URL/set/meta:last_heartbeat/$NOW"
+          echo "wrote meta:last_heartbeat=$NOW"

--- a/.github/workflows/persona-walk-nightly.yml
+++ b/.github/workflows/persona-walk-nightly.yml
@@ -114,3 +114,23 @@ jobs:
         run: |
           node .github/scripts/findings-to-issues.mjs \
             --findings "tests/visual/out/persona-walks/$stamp/findings.json"
+
+      - name: Check Mac Mini heartbeat staleness
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          AGE=$(curl -fsS https://smokysignal.app/api/health | jq -r '.last_heartbeat_age_s // "null"')
+          echo "heartbeat age: $AGE seconds"
+          # 5400 = 90 minutes
+          if [ "$AGE" = "null" ] || [ "$AGE" -gt 5400 ]; then
+            EXISTING=$(gh issue list --label infra-alert --state open --search "Mac Mini heartbeat" --json number --jq 'length')
+            if [ "$EXISTING" = "0" ]; then
+              gh issue create \
+                --title "infra-alert: Mac Mini heartbeat stale (${AGE}s)" \
+                --body "Latest heartbeat in KV is ${AGE} seconds old (threshold: 5400 = 90 min). The hourly heartbeat workflow may have stopped firing, or the KV write is failing. Check: .github/workflows/heartbeat.yml schedule, KV_REST_API_URL/KV_REST_API_TOKEN secrets, /api/health endpoint." \
+                --label infra-alert
+              echo "opened infra-alert issue"
+            else
+              echo "existing infra-alert issue still open — skipping create"
+            fi
+          fi

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -94,6 +94,7 @@ export async function GET() {
     opensky_credits_remaining,
     snap,
     last_airborne_ts,
+    last_heartbeat_ts,
   ] = await Promise.all([
     pingKv(),
     pingUrl(adsbfiUrl),
@@ -101,6 +102,7 @@ export async function GET() {
     getOpenskyCreditsRemaining(),
     peekHealthSnapshot(),
     getLastAirborneTs(),
+    cacheGet<number>("meta:last_heartbeat"),
   ]);
 
   // Counts derived from the cached snapshot. live_seen_count = total
@@ -120,6 +122,18 @@ export async function GET() {
   // adsb.fi is the only path that must work for the app to be useful;
   // OpenSky is a fallback. KV is optional (in-memory fallback exists).
   const ok = adsbfi === "ok";
+  // CI heartbeat — written by .github/workflows/heartbeat.yml hourly.
+  // Surfaced here so the nightly persona-walk workflow can detect Mac
+  // Mini outages and verify-prod can assert freshness.
+  const last_heartbeat_age_s =
+    typeof last_heartbeat_ts === "number" && Number.isFinite(last_heartbeat_ts)
+      ? Math.max(0, Math.floor(Date.now() / 1000 - last_heartbeat_ts))
+      : null;
+  const last_heartbeat_iso =
+    typeof last_heartbeat_ts === "number" && Number.isFinite(last_heartbeat_ts)
+      ? new Date(last_heartbeat_ts * 1000).toISOString()
+      : null;
+
   return NextResponse.json({
     ok,
     kv,
@@ -130,6 +144,8 @@ export async function GET() {
     last_airborne_ts: last_airborne_ts
       ? new Date(last_airborne_ts).toISOString()
       : null,
+    last_heartbeat_iso,
+    last_heartbeat_age_s,
     opensky: openskyResult.status,
     ...(openskyResult.error ? { opensky_error: openskyResult.error } : {}),
     opensky_credits_remaining,

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -632,4 +632,42 @@ test.describe("p14 live-prod audit", () => {
       screenshot,
     });
   });
+
+  test("19. /api/health surfaces last_heartbeat fields (P22 5)", async ({
+    request,
+  }) => {
+    const r = await request.get("/api/health");
+    let evidence = `HTTP ${r.status()}`;
+    let pass = false;
+    let category: Finding["category"] = "confirmed_bug";
+    if (r.ok()) {
+      const data = (await r.json()) as {
+        last_heartbeat_iso: string | null;
+        last_heartbeat_age_s: number | null;
+      };
+      const fieldsPresent =
+        "last_heartbeat_iso" in data && "last_heartbeat_age_s" in data;
+      const fresh =
+        typeof data.last_heartbeat_age_s === "number" &&
+        data.last_heartbeat_age_s < 5400;
+      pass = fieldsPresent;
+      category = fieldsPresent
+        ? fresh
+          ? "working_as_designed"
+          : "indeterminate"
+        : "confirmed_bug";
+      evidence = fieldsPresent
+        ? data.last_heartbeat_iso == null
+          ? "fields present; heartbeat not yet written (workflow has not fired)"
+          : `heartbeat ${data.last_heartbeat_age_s}s old (${data.last_heartbeat_iso})`
+        : "expected fields missing from /api/health response";
+    }
+    record({
+      claim:
+        "/api/health surfaces last_heartbeat_iso + last_heartbeat_age_s — Mac Mini heartbeat freshness",
+      category,
+      pass,
+      evidence,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P22 Phase 5. Hourly GitHub Actions workflow writes \`meta:last_heartbeat\` (epoch seconds) to KV. \`/api/health\` exposes it. Nightly persona-walk workflow opens an infra-alert issue if older than 90 min.

## Changes

| File | Purpose |
|---|---|
| \`.github/workflows/heartbeat.yml\` | Cron \`0 * * * *\` — Upstash REST set call |
| \`app/api/health/route.ts\` | Reads \`meta:last_heartbeat\`, exposes \`last_heartbeat_iso\` + \`last_heartbeat_age_s\` |
| \`.github/workflows/persona-walk-nightly.yml\` | New step — \`gh issue create\` (deduped by title) when stale |
| \`tests/visual/specs/p14-live-prod-audit.spec.ts\` | New assertion #19 |

## Required secrets

- \`KV_REST_API_URL\`
- \`KV_REST_API_TOKEN\`

Both should already be in repo Secrets (they're used by other workflows). Auto-skips with a warning if missing.

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertion #19 added (passes when fields are present, marked indeterminate before first heartbeat fires)
- [ ] CI build gate
- [ ] **Manual after merge:** trigger heartbeat workflow via \`workflow_dispatch\` once to populate the key, then re-run verify-prod

## Lines

114 added / 0 deleted — well under the ≤200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)