### PR TITLE
feat(ci): triage classifier — Haiku decides auto-fixable/needs-human/personalization-gap

### DIFF
--- a/.github/workflows/triage-finding.yml
+++ b/.github/workflows/triage-finding.yml
@@ -1,0 +1,116 @@
+name: Triage finding
+
+# When a new finding-issue lands (auto-created by the nightly sweep or
+# manually filed with one of the known labels), classify it via a small
+# Haiku call into one of three buckets:
+#
+#   - auto-fixable        → fits the allow-list (voice copy, alt text,
+#                           single-line copy fixes); the autofix-issue
+#                           workflow can take it from here.
+#   - needs-human         → judgment call or touches deny-listed paths.
+#   - personalization-gap → persona-specific taste; should become a
+#                           setting, not a bug fix.
+#
+# Auto-skips if CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY missing.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+concurrency:
+  group: triage-finding-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: |
+      contains(github.event.issue.labels.*.name, 'nightly-finding') ||
+      contains(github.event.issue.labels.*.name, 'voice-violation') ||
+      contains(github.event.issue.labels.*.name, 'a11y-violation') ||
+      contains(github.event.issue.labels.*.name, 'persona-walk')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip if already triaged
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABELS=$(gh issue view ${{ github.event.issue.number }} --json labels --jq '[.labels[].name] | join(" ")')
+          if echo " $LABELS " | grep -qE " (auto-fixable|needs-human|personalization-gap) "; then
+            echo "skipped=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::issue already classified — skipping"
+          fi
+
+      - name: Build triage prompt
+        if: steps.gate.outputs.skipped != '1'
+        env:
+          BODY: ${{ github.event.issue.body }}
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          {
+            echo "You are the triage classifier for SmokySignal persona-walk findings."
+            echo ""
+            echo "Allow-listed paths (auto-fixable scope):"
+            echo "  content/*.md, app/(tabs)/*/page.tsx, components/*.tsx (excluding admin/dev/debug), app/layout.tsx, public/manifest.json"
+            echo ""
+            echo "Deny-listed paths (needs-human scope):"
+            echo "  lib/, app/api/, app/admin/, lib/brand/, .github/, anything that affects data flow or auth"
+            echo ""
+            echo "Output format: first line is a single token (one of: auto-fixable | needs-human | personalization-gap). Second line is exactly one sentence justifying the choice. No prose before the first line."
+            echo ""
+            echo "Rules:"
+            echo "- auto-fixable iff (a) the fix is contained to allow-listed paths AND (b) the fix is clearly correct without design judgment"
+            echo "- personalization-gap iff the finding is a single-persona taste call (e.g. 'I want this in 12-hour time' — should be a setting)"
+            echo "- needs-human if neither criterion fits"
+            echo ""
+            echo "<issue-title>$TITLE</issue-title>"
+            echo "<issue-body>"
+            echo "$BODY"
+            echo "</issue-body>"
+          } > /tmp/prompt.txt
+
+      - name: Classify via claude --print
+        if: steps.gate.outputs.skipped != '1'
+        id: classify
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning::No Claude auth secret — defaulting to needs-human."
+            echo "verdict=needs-human" >> "$GITHUB_OUTPUT"
+            echo "justification=No auth secret configured — manual triage required." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          OUT=$(claude -p --model claude-haiku-4-5 --tools "" --disable-slash-commands --strict-mcp-config --no-session-persistence --permission-mode acceptEdits < /tmp/prompt.txt)
+          echo "raw output: $OUT"
+          VERDICT=$(echo "$OUT" | head -1 | tr -d '[:space:]')
+          JUSTIFICATION=$(echo "$OUT" | sed -n '2,$p' | head -3 | tr '\n' ' ')
+          case "$VERDICT" in
+            auto-fixable|needs-human|personalization-gap) ;;
+            *) VERDICT=needs-human; JUSTIFICATION="Classifier output unparseable — defaulting to needs-human. Raw: $OUT" ;;
+          esac
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          {
+            echo "justification<<EOF_J"
+            echo "$JUSTIFICATION"
+            echo "EOF_J"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply label + comment
+        if: steps.gate.outputs.skipped != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} --add-label "${{ steps.classify.outputs.verdict }}"
+          gh issue comment ${{ github.event.issue.number }} --body "Triage classifier (claude-haiku-4-5): **${{ steps.classify.outputs.verdict }}**
+
+> ${{ steps.classify.outputs.justification }}
+
+_Auto-applied. If wrong, remove the label manually and the autofix worker will not pick this up._"


### PR DESCRIPTION
## Summary

P22 Phase 1. Auto-classifies new finding-issues into three buckets so the autofix worker (Phase 2) only picks up safe ones.

## Trigger

\`issues\` event types \`opened\` or \`labeled\` filtered to:
- \`nightly-finding\` (auto-issued by the nightly sweep)
- \`voice-violation\`, \`a11y-violation\` (future workflows)
- \`persona-walk\` (existing tag from P19/P20 issue stream)

## Output

Applies one of three labels + a justification comment:

| Verdict | Means |
|---|---|
| \`auto-fixable\` | Allow-listed path, no design judgment needed |
| \`needs-human\` | Touches deny-listed path OR requires judgment |
| \`personalization-gap\` | Single-persona taste call → should become a setting |

## Auth path

\`CLAUDE_CODE_OAUTH_TOKEN\` preferred, \`ANTHROPIC_API_KEY\` fallback. Without either, defaults to \`needs-human\` (conservative — no auto-fix runs without explicit auth).

## Test plan

- [x] YAML valid
- [x] Allow-listed path (\`.github/\` only)
- [x] Skip-if-already-classified guard
- [x] Output normalization (default to needs-human on unparseable output)
- [ ] **Manual after merge:** open a synthetic test issue with label \`nightly-finding\` and watch the workflow apply a verdict

## Lines

116 — well under the ≤200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)