### PR TITLE
feat(ci): auto-fix worker + close-on-merge tracing

### DIFF
--- a/.github/workflows/autofix-issue.yml
+++ b/.github/workflows/autofix-issue.yml
@@ -1,0 +1,183 @@
+name: Auto-fix issue
+
+# Triggered when an issue is labeled `auto-fixable` (typically by the
+# Phase-1 triage classifier). Calls Sonnet to produce a unified diff
+# scoped to allow-listed paths, applies it on a fresh branch, opens a
+# PR. Existing voice-gate + per-PR persona-walk gate the merge.
+#
+# Skips if the issue also carries `blocked` or `in-progress`.
+
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: autofix-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  autofix:
+    if: |
+      github.event.label.name == 'auto-fixable' &&
+      !contains(github.event.issue.labels.*.name, 'blocked') &&
+      !contains(github.event.issue.labels.*.name, 'in-progress')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build fix prompt
+        env:
+          BODY: ${{ github.event.issue.body }}
+          TITLE: ${{ github.event.issue.title }}
+        run: |
+          {
+            echo "You are auto-fixing a SmokySignal persona-walk finding. Read the issue and produce a unified diff that resolves it."
+            echo ""
+            echo "STRICT RULES:"
+            echo "1. Output ONLY a unified diff (git format-patch style, with 'diff --git a/... b/...' headers). No prose, no fences."
+            echo "2. Touch ONLY these paths:"
+            echo "   - content/*.md"
+            echo "   - app/(tabs)/*/page.tsx"
+            echo "   - components/*.tsx (excluding admin/dev/debug)"
+            echo "   - app/layout.tsx"
+            echo "   - public/manifest.json"
+            echo "3. The diff must apply cleanly via 'git apply' against the current main branch."
+            echo "4. Brand voice rules from design/BRAND.md still apply (no emoji, no exclamation marks, no banned vocab)."
+            echo "5. Keep the diff small — one fix, no scope creep."
+            echo ""
+            echo "<issue-title>$TITLE</issue-title>"
+            echo "<issue-body>"
+            echo "$BODY"
+            echo "</issue-body>"
+            echo ""
+            echo "Use the Read tool to inspect any allow-listed file before producing the diff."
+          } > /tmp/prompt.txt
+
+      - name: Generate fix via Sonnet
+        id: fix
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::No Claude auth secret configured — cannot run autofix."
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          set +e
+          claude -p --model claude-sonnet-4-6 \
+            --tools "Read" \
+            --disable-slash-commands \
+            --strict-mcp-config \
+            --no-session-persistence \
+            --permission-mode acceptEdits \
+            < /tmp/prompt.txt > /tmp/diff.patch
+          STATUS=$?
+          set -e
+          if [ $STATUS -ne 0 ] || [ ! -s /tmp/diff.patch ]; then
+            echo "::warning::Sonnet produced no diff or non-zero exit ($STATUS)"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Strip any leading/trailing prose around the diff.
+          sed -n '/^diff --git/,$p' /tmp/diff.patch > /tmp/clean.patch
+          if ! grep -q '^diff --git' /tmp/clean.patch; then
+            echo "::warning::No 'diff --git' header in output"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ok=1" >> "$GITHUB_OUTPUT"
+
+      - name: Validate paths in diff (allow-list)
+        if: steps.fix.outputs.ok == '1'
+        id: validate
+        run: |
+          # Extract every path the diff touches, fail if any is denied.
+          PATHS=$(grep '^diff --git' /tmp/clean.patch | awk '{print $4}' | sed 's|^b/||' | sort -u)
+          echo "paths touched: $PATHS"
+          DENIED=$(echo "$PATHS" | grep -vE '^(content/.*\.md|app/\(tabs\)/[^/]+/page\.tsx|components/[^/]+\.tsx|app/layout\.tsx|public/manifest\.json)$' || true)
+          if [ -n "$DENIED" ]; then
+            echo "::error::Diff touches deny-listed paths: $DENIED"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Also reject components/admin*, components/debug*, components/dev*
+          NESTED=$(echo "$PATHS" | grep -E '^components/(admin|debug|dev)' || true)
+          if [ -n "$NESTED" ]; then
+            echo "::error::Diff touches reserved components: $NESTED"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ok=1" >> "$GITHUB_OUTPUT"
+
+      - name: Apply diff + build
+        if: steps.fix.outputs.ok == '1' && steps.validate.outputs.ok == '1'
+        id: apply
+        run: |
+          BR="autofix-issue-${{ github.event.issue.number }}"
+          git checkout -b "$BR"
+          if ! git apply --check /tmp/clean.patch; then
+            echo "::warning::diff doesn't apply cleanly"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git apply /tmp/clean.patch
+          npm ci --no-audit --no-fund
+          if ! npm run build > /tmp/build.log 2>&1; then
+            tail -50 /tmp/build.log
+            echo "::warning::build failed after applying diff"
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git add -A
+          git commit -m "fix(autofix): close #${{ github.event.issue.number }} — auto-generated diff
+
+Sonnet-generated, scoped to allow-listed paths. Closes #${{ github.event.issue.number }}.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+          git push -u origin "$BR"
+          echo "branch=$BR" >> "$GITHUB_OUTPUT"
+          echo "ok=1" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR + relabel issue
+        if: steps.apply.outputs.ok == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "fix(autofix): close #${{ github.event.issue.number }}" \
+            --body "Auto-fix from issue #${{ github.event.issue.number }}.
+
+Closes #${{ github.event.issue.number }}.
+
+Sonnet-generated unified diff, scoped to allow-listed paths only. Voice gate + per-PR persona-walk gate run automatically; PR auto-merges if both pass.
+
+🤖 Generated by .github/workflows/autofix-issue.yml" \
+            --head "${{ steps.apply.outputs.branch }}" \
+            --base main
+          gh pr merge --auto --squash "${{ steps.apply.outputs.branch }}" || true
+          gh issue edit ${{ github.event.issue.number }} --add-label in-progress --remove-label auto-fixable
+
+      - name: Comment failure on issue
+        if: steps.fix.outputs.ok == '0' || steps.validate.outputs.ok == '0' || steps.apply.outputs.ok == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "Auto-fix worker could not produce a clean diff for this issue (see workflow run for detail). Removing the auto-fixable label and adding needs-human."
+          gh issue edit ${{ github.event.issue.number }} --remove-label auto-fixable --add-label needs-human

--- a/.github/workflows/close-issue-on-merge.yml
+++ b/.github/workflows/close-issue-on-merge.yml
@@ -1,0 +1,41 @@
+name: Close issue on merge
+
+# When a PR with "Closes #N" merges, GitHub's native behavior already
+# closes the issue. This workflow adds a tracing comment so the auto-fix
+# loop is observable from the issue thread alone — useful for the QA
+# dashboard's throughput stats.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  comment-on-issue:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Find linked issues + comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Match closes/fixes/resolves #N (case-insensitive).
+          MATCHES=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
+            | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' \
+            | grep -oE '#[0-9]+' \
+            | sed 's/#//' \
+            | sort -u)
+          if [ -z "$MATCHES" ]; then
+            echo "No Closes #N references — nothing to do."
+            exit 0
+          fi
+          for N in $MATCHES; do
+            echo "Commenting on #$N"
+            gh issue comment "$N" --body "Auto-fixed and merged via PR #${PR_NUMBER}." || true
+          done


### PR DESCRIPTION
## Summary

P22 Phase 2. Closes the auto-fix loop end-to-end.

## \`autofix-issue.yml\`

Fires when an issue is labeled \`auto-fixable\` (typically by the Phase-1 triage classifier). Skips if also carrying \`blocked\` or \`in-progress\`.

| Step | Action |
|---|---|
| 1 | Build fix prompt (issue + allow-listed paths + strict diff-only) |
| 2 | Pipe to Sonnet via \`claude --print\` |
| 3 | Strip prose; validate every touched path against allow-list |
| 4 | \`git apply\` on \`autofix-issue-{N}\`, \`npm run build\`, commit, push |
| 5 | Open PR with \`Closes #N\`, enable auto-merge, relabel issue \`auto-fixable\` → \`in-progress\` |
| 6 | On any failure: comment on issue, relabel \`auto-fixable\` → \`needs-human\` |

The existing voice-gate + per-PR persona-walk gate (P20) runs on the generated PR; auto-merge waits for both.

## \`close-issue-on-merge.yml\`

When a PR with \`Closes #N\` / \`Fixes #N\` / \`Resolves #N\` merges, comments on the linked issue ("Auto-fixed and merged via PR #X"). GitHub's native auto-close handles the actual close; this comment makes the loop observable from the issue thread alone — useful for the Phase 4 dashboard's throughput stats.

## Path allow-list

- \`content/*.md\`
- \`app/(tabs)/*/page.tsx\`
- \`components/*.tsx\` (excluding admin/dev/debug)
- \`app/layout.tsx\`
- \`public/manifest.json\`

## Test plan

- [x] YAML valid
- [x] All paths under \`.github/\`
- [ ] **Manual after merge:** open a synthetic auto-fixable issue (e.g. "voice violation: emoji on /about") and watch the loop end-to-end

## Lines

224 (183 autofix + 41 close-on-merge). Slightly over the 200 soft gate; the autofix workflow needs the validation gates to be safe-by-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)