### PR TITLE
feat(testing): visual regression diff vs latest nightly baseline

### DIFF
--- a/.github/scripts/visual-diff.sh
+++ b/.github/scripts/visual-diff.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Walk two parallel sweep directories and emit a diff summary in JSON
+# on stdout. Uses ImageMagick's compare metric AE (absolute error —
+# count of differing pixels) and `identify` for total pixel count.
+#
+# Usage: visual-diff.sh <baseline-dir> <current-dir>
+#
+# Both dirs are expected to be `out/persona-walks/<stamp>/` shaped:
+#   <stamp>/<persona>/<route>.png
+#
+# Threshold: route flagged as "changed" when diff ratio > 0.05 (5%).
+
+set -euo pipefail
+
+BASELINE_DIR="${1:?usage: visual-diff.sh <baseline-dir> <current-dir>}"
+CURRENT_DIR="${2:?usage: visual-diff.sh <baseline-dir> <current-dir>}"
+THRESHOLD="${VISUAL_DIFF_THRESHOLD:-0.05}"
+
+results_file=$(mktemp)
+echo "[]" > "$results_file"
+
+walk() {
+  local current_png base persona route ratio diff total
+  while IFS= read -r -d '' current_png; do
+    persona=$(basename "$(dirname "$current_png")")
+    route=$(basename "$current_png" .png)
+    base="$BASELINE_DIR/$persona/$route.png"
+
+    if [ ! -f "$base" ]; then
+      jq --arg p "$persona" --arg r "$route" \
+        '. + [{persona:$p, route:$r, status:"new"}]' \
+        "$results_file" > "$results_file.tmp" && mv "$results_file.tmp" "$results_file"
+      continue
+    fi
+
+    total=$(identify -format "%[fx:w*h]" "$current_png" 2>/dev/null || echo 0)
+    [ "$total" = "0" ] && continue
+    diff=$(compare -metric AE "$current_png" "$base" /dev/null 2>&1 || true)
+    diff="${diff%% *}"
+    [[ "$diff" =~ ^[0-9]+$ ]] || diff=0
+    ratio=$(awk "BEGIN{ printf \"%.4f\", $diff / $total }")
+
+    if awk "BEGIN{ exit !($ratio > $THRESHOLD) }"; then
+      status="changed"
+    else
+      status="ok"
+    fi
+
+    jq --arg p "$persona" --arg r "$route" --arg s "$status" \
+       --argjson diff "$diff" --argjson total "$total" --argjson ratio "$ratio" \
+      '. + [{persona:$p, route:$r, status:$s, diff_pixels:$diff, total:$total, ratio:$ratio}]' \
+      "$results_file" > "$results_file.tmp" && mv "$results_file.tmp" "$results_file"
+  done < <(find "$CURRENT_DIR" -mindepth 2 -maxdepth 2 -name '*.png' -print0)
+}
+
+walk
+cat "$results_file"
+rm -f "$results_file"

--- a/.github/workflows/persona-walk-pr.yml
+++ b/.github/workflows/persona-walk-pr.yml
@@ -129,6 +129,32 @@ jobs:
             npx tsx personas/aggregate-consensus.ts --sweep-dir "$SWEEP"
           fi
 
+      - name: Visual regression diff vs latest nightly
+        if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
+        id: vdiff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh run list --workflow persona-walk-nightly.yml --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [ -z "$LATEST" ]; then
+            echo "No prior nightly run — skipping visual diff."
+            echo '[]' > /tmp/visual-diff.json
+            exit 0
+          fi
+          ART=$(gh api "repos/${{ github.repository }}/actions/runs/$LATEST/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("persona-walk-nightly-")) | .name' \
+            | head -1)
+          if [ -z "$ART" ]; then
+            echo "No baseline artifact on run $LATEST — skipping visual diff."
+            echo '[]' > /tmp/visual-diff.json
+            exit 0
+          fi
+          mkdir -p /tmp/baseline
+          gh run download "$LATEST" --name "$ART" --dir /tmp/baseline || true
+          .github/scripts/visual-diff.sh /tmp/baseline "tests/visual/out/persona-walks/$stamp" \
+            > /tmp/visual-diff.json || echo '[]' > /tmp/visual-diff.json
+          cat /tmp/visual-diff.json
+
       - name: Upload sweep artifact
         if: steps.routes.outputs.skipped != '1' && steps.vercel.outputs.skipped != '1'
         uses: actions/upload-artifact@v4
@@ -148,8 +174,24 @@ jobs:
             const fs = require('fs');
             const p = `tests/visual/out/persona-walks/${process.env.stamp}/consensus.md`;
             const head = `## Persona walk on Vercel preview\n\n**Preview:** ${process.env.PREVIEW}\n**Routes:** \`${process.env.ROUTES}\`\n**Personas:** sport-bike-rider, skeptic, lurker, low-vision-rider\n\n---\n\n`;
+            let visual = '';
+            try {
+              const v = JSON.parse(fs.readFileSync('/tmp/visual-diff.json', 'utf8'));
+              if (Array.isArray(v) && v.length > 0) {
+                const changed = v.filter((x) => x.status === 'changed');
+                const newly = v.filter((x) => x.status === 'new');
+                visual = `\n\n### Visual regression vs latest nightly\n\n` +
+                  `- ${changed.length} route(s) over 5% diff threshold\n` +
+                  `- ${newly.length} route(s) new vs baseline\n\n`;
+                if (changed.length > 0) {
+                  visual += `Changed:\n` +
+                    changed.map((x) => `- \`${x.persona}/${x.route}\` — ${(x.ratio * 100).toFixed(2)}% (${x.diff_pixels}/${x.total} px)`).join('\n') + '\n';
+                }
+                visual += `\n_Warn-only — UI changes are often intentional. Review the artifact for side-by-sides._`;
+              }
+            } catch (e) { /* visual diff missing — skip */ }
             const tail = `\n\n_Full sweep + screenshots: workflow artifacts._`;
-            const body = head + (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '_consensus.md missing._') + tail;
+            const body = head + (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '_consensus.md missing._') + visual + tail;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

P22 Phase 3. Per-PR walk now diffs each route's screenshot against the latest nightly baseline. Posts a summary in the PR comment.

## How it works

The nightly sweep already captures full-page PNGs per persona × route as a 90-day workflow artifact. The per-PR workflow:

1. \`gh run list --workflow persona-walk-nightly.yml --status success --limit 1\` — find the latest nightly run
2. \`gh api .../artifacts\` — find the artifact name
3. \`gh run download\` — pull the baseline into \`/tmp/baseline\`
4. \`.github/scripts/visual-diff.sh\` — walk current sweep dir, ImageMagick \`compare -metric AE\` per pair, JSON to stdout
5. Embed summary in the PR comment

## Per-route status

| Status | Meaning |
|---|---|
| \`ok\` | Diff under 5% pixel-ratio threshold |
| \`changed\` | Diff over threshold — surfaced in comment |
| \`new\` | Route in PR sweep but not in baseline |

Threshold tunable via \`VISUAL_DIFF_THRESHOLD\` env var.

## Warn-only by design

UI changes are often intentional. The diff posts to the PR but doesn't fail the build. Operator decides whether to escalate to a hard fail later (open item).

## Test plan

- [x] \`visual-diff.sh\` smoke-tested locally — handles missing baseline (\"new\" status), missing ImageMagick (silently empty), and matched pairs
- [x] YAML valid; allow-listed paths only (\`.github/\`)
- [ ] CI build gate
- [ ] **Manual after merge:** the next PR with rider-facing changes should produce a visual-diff section in its comment

## Lines

101 added — well under the 200 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)