### PR TITLE
feat(qa): /qa-dashboard admin-gated page + docs/qa-dashboard.md

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -48,6 +48,7 @@ function requireAdmin() {
 const VALID_NEXT_TARGETS: Record<string, string> = {
   tracks: "/admin/tracks",
   spots: "/admin/spots",
+  qa: "/qa-dashboard",
 };
 
 export async function authenticateAction(formData: FormData) {

--- a/app/qa-dashboard/page.tsx
+++ b/app/qa-dashboard/page.tsx
@@ -1,0 +1,148 @@
+// QA dashboard. Operator-facing, admin-passcode-gated. Reads
+// docs/qa-dashboard.md from the deployed bundle for the static body
+// + KV for the live heartbeat. Render is intentionally minimal —
+// this is operator info, not a rider surface.
+
+import { redirect } from "next/navigation";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  isAdminAuthed,
+  isAdminPasscodeConfigured,
+} from "@/lib/admin-auth";
+import { cacheGet } from "@/lib/cache";
+import { SS_TOKENS } from "@/lib/tokens";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "SmokySignal · QA dashboard",
+  robots: { index: false, follow: false },
+};
+
+async function loadBody(): Promise<string> {
+  try {
+    const p = path.resolve(process.cwd(), "docs/qa-dashboard.md");
+    return await fs.readFile(p, "utf8");
+  } catch {
+    return "_docs/qa-dashboard.md not deployed in this build._";
+  }
+}
+
+function formatHeartbeat(ts: number | null): {
+  iso: string;
+  age: string;
+  color: string;
+} {
+  if (ts == null) {
+    return { iso: "never", age: "—", color: SS_TOKENS.fg2 };
+  }
+  const ageS = Math.max(0, Math.floor(Date.now() / 1000 - ts));
+  const ageMin = Math.floor(ageS / 60);
+  const stale = ageS > 5400;
+  const ageStr =
+    ageMin < 1
+      ? "just now"
+      : ageMin < 60
+        ? `${ageMin}m ago`
+        : `${Math.floor(ageMin / 60)}h ${ageMin % 60}m ago`;
+  return {
+    iso: new Date(ts * 1000).toISOString(),
+    age: ageStr,
+    color: stale ? SS_TOKENS.alert : SS_TOKENS.clear,
+  };
+}
+
+export default async function QADashboardPage() {
+  if (!isAdminPasscodeConfigured()) {
+    return (
+      <main style={{ padding: 32, maxWidth: 720, margin: "0 auto", color: SS_TOKENS.fg0 }}>
+        <h1 style={{ marginTop: 0 }}>QA dashboard</h1>
+        <p style={{ color: SS_TOKENS.fg1 }}>
+          <code className="ss-mono">ADMIN_PASSCODE</code> isn&rsquo;t set in
+          this environment. Configure the env var to enable the dashboard.
+        </p>
+      </main>
+    );
+  }
+  if (!isAdminAuthed()) {
+    redirect("/admin?next=qa");
+  }
+
+  const [body, lastHeartbeatTs] = await Promise.all([
+    loadBody(),
+    cacheGet<number>("meta:last_heartbeat"),
+  ]);
+  const hb = formatHeartbeat(lastHeartbeatTs ?? null);
+
+  return (
+    <main
+      style={{
+        padding: 32,
+        maxWidth: 900,
+        margin: "0 auto",
+        color: SS_TOKENS.fg0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 18,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 12,
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: 24 }}>QA dashboard</h1>
+        <a
+          href="/"
+          className="ss-mono"
+          style={{ fontSize: 11, color: SS_TOKENS.fg2, textDecoration: "none" }}
+        >
+          ← Home
+        </a>
+      </header>
+
+      <section
+        style={{
+          background: SS_TOKENS.bg1,
+          border: `.5px solid ${SS_TOKENS.hairline}`,
+          borderRadius: 12,
+          padding: "12px 16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        <div className="ss-eyebrow" style={{ color: SS_TOKENS.fg2 }}>
+          Mac Mini heartbeat
+        </div>
+        <div className="ss-mono" style={{ fontSize: 14, color: hb.color }}>
+          {hb.age}
+          {lastHeartbeatTs != null ? ` · ${hb.iso}` : ""}
+        </div>
+        <div style={{ fontSize: 11, color: SS_TOKENS.fg2 }}>
+          Threshold for infra-alert: &gt; 90 min stale.
+        </div>
+      </section>
+
+      <pre
+        style={{
+          background: SS_TOKENS.bg1,
+          border: `.5px solid ${SS_TOKENS.hairline}`,
+          borderRadius: 12,
+          padding: "16px 20px",
+          fontSize: 12.5,
+          lineHeight: 1.6,
+          color: SS_TOKENS.fg0,
+          whiteSpace: "pre-wrap",
+          overflowX: "auto",
+        }}
+      >
+        {body}
+      </pre>
+    </main>
+  );
+}

--- a/docs/qa-dashboard.md
+++ b/docs/qa-dashboard.md
@@ -1,0 +1,44 @@
+# SmokySignal QA dashboard
+
+Operator-facing snapshot of the continuous testing pipeline. Lives at
+`/qa-dashboard` (admin-passcode-gated). The pipeline itself runs across
+several GitHub Actions workflows; this file is the canonical surface for
+"is the operator's eye on the right things?"
+
+## Pipeline surfaces
+
+| Surface | Trigger | Output |
+|---|---|---|
+| `voice-gate.yml` | every PR | PR comment, fails on P0 violations |
+| `persona-walk-pr.yml` | every PR with rider-facing changes | PR comment with consensus + visual diff |
+| `persona-walk-nightly.yml` | cron 04:00 PT | 90d artifact, auto-issues for new high-signal findings |
+| `triage-finding.yml` | issue opened/labeled | applies `auto-fixable` / `needs-human` / `personalization-gap` |
+| `autofix-issue.yml` | issue labeled `auto-fixable` | opens PR with Sonnet-generated diff |
+| `close-issue-on-merge.yml` | PR merged | comments back-pointer on linked issues |
+| `heartbeat.yml` | cron hourly | KV write — Mac Mini liveness |
+| `build.yml` | every PR + push to main | tsc + Next.js build |
+| `verify-prod` | manual / pre-push | `tests/visual/specs/p14-live-prod-audit.spec.ts` |
+
+## What lives where
+
+- **Persona files:** `tests/visual/personas/persona-files/persona-*.md` — 9 personas including `low-vision-rider` (P21).
+- **Mock state machine:** `lib/mock-state.ts` — `?mock=up|down|eyes-up|multiple|stale|learning|full-data`.
+- **Voice rules:** `.github/scripts/voice-gate.mjs` (banned vocab, emoji, exclamation marks). Source of truth: `design/BRAND.md` §3 + §8.
+- **Verify-prod spec:** `tests/visual/specs/p14-live-prod-audit.spec.ts` — 19 assertions as of P22.
+- **Visual diff:** `.github/scripts/visual-diff.sh` — ImageMagick-based, 5% pixel-ratio threshold.
+
+## Manual checks the dashboard doesn't replace
+
+- Reading the consensus.md from the latest nightly sweep
+- Triaging `needs-human` issues
+- Skimming a sample of voice-gate comments to recalibrate the rule list
+- Periodic spot-check of the auto-fix worker's diffs to confirm they're sane
+
+## Phase-4 v1 scope
+
+This page renders the Mac Mini heartbeat live, plus this static body. Auto-
+regeneration of the body from issue counts + workflow run statistics is a
+follow-up — the data sources are all reachable (`gh` API, GitHub Actions
+runs API, `/api/health`), but wiring them into a live page renderer adds
+PR-budget that wasn't load-bearing for v1. Track in
+`p22-deferred-dashboard-live-data` if you want the upgrade.

--- a/tests/visual/specs/p14-live-prod-audit.spec.ts
+++ b/tests/visual/specs/p14-live-prod-audit.spec.ts
@@ -633,6 +633,37 @@ test.describe("p14 live-prod audit", () => {
     });
   });
 
+  test("20. /qa-dashboard exists + admin-gated (P22 4)", async ({ page }) => {
+    await page.goto("/qa-dashboard", { waitUntil: "networkidle" });
+    await page.waitForTimeout(800);
+    const screenshot = await shot(page, "20-qa-dashboard-gate");
+    const url = page.url();
+    const body = (await page.locator("body").innerText()).slice(0, 600);
+    // Three valid surfaces:
+    //  (a) ADMIN_PASSCODE not configured → friendly message
+    //  (b) Not authed → redirect to /admin?next=qa
+    //  (c) Authed → dashboard renders (won't happen from prod audit
+    //      without a session)
+    const passcodeMissing = /ADMIN_PASSCODE/.test(body);
+    const redirectedToAdmin = /\/admin/.test(url) && /next=qa/.test(url);
+    const dashboardRendered = /QA dashboard/.test(body) && /Mac Mini heartbeat/.test(body);
+    const pass = passcodeMissing || redirectedToAdmin || dashboardRendered;
+    record({
+      claim:
+        "/qa-dashboard responds (admin-gated): redirects to /admin?next=qa, shows ADMIN_PASSCODE-missing surface, or renders the dashboard",
+      category: pass ? "working_as_designed" : "confirmed_bug",
+      pass,
+      evidence: passcodeMissing
+        ? "passcode-missing surface rendered"
+        : redirectedToAdmin
+          ? `redirected to ${url}`
+          : dashboardRendered
+            ? "dashboard rendered (admin session present)"
+            : `unexpected response: url=${url} body-prefix="${body.slice(0, 120)}"`,
+      screenshot,
+    });
+  });
+
   test("19. /api/health surfaces last_heartbeat fields (P22 5)", async ({
     request,
   }) => {


### PR DESCRIPTION
## Summary

P22 Phase 4 v1. Operator-facing dashboard at \`/qa-dashboard\`, gated by the existing \`ADMIN_PASSCODE\` auth flow.

## What it shows

- **Live Mac Mini heartbeat** — formatted age + ISO timestamp, amber when stale (> 90 min, matches the nightly's infra-alert threshold)
- **Static body** from \`docs/qa-dashboard.md\` — pipeline surfaces table, what-lives-where index, manual checks the dashboard doesn't replace

## How it auths

Reuses \`/admin\`'s authenticate action. \`qa → /qa-dashboard\` added to \`VALID_NEXT_TARGETS\`. Unauthed visitors hit \`/admin?next=qa\`, log in, bounce back.

## Out of scope (deferred)

Auto-regeneration of the markdown body from issue counts + workflow run statistics. The data sources are reachable (\`gh\` API + Actions runs API + \`/api/health\`) but wiring them adds budget that wasn't load-bearing for v1.

## Test plan

- [x] \`npm run build\` passes; \`/qa-dashboard\` shows in the route table
- [x] \`npx tsc --noEmit\` clean
- [x] verify-prod assertion #20 added — accepts any of three valid surfaces
- [ ] CI build gate
- [ ] **Manual after merge:** visit \`https://smokysignal.app/qa-dashboard\`, redirect to /admin login, log in with passcode, see the dashboard with live heartbeat

## Lines

224 — slightly over the 200 soft gate. The page itself is most of it; the markdown + spec assertion are small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)