### PR TITLE
fix(dash): route Recent activity timestamps through canonical fmtAgoTs

### DIFF
--- a/components/DashShell.tsx
+++ b/components/DashShell.tsx
@@ -8,6 +8,7 @@ import { SS_TOKENS } from "@/lib/tokens";
 import { SMOKY_TAIL } from "@/lib/seed";
 import { DEFAULT_SPEED_LIMIT_MPH, haversineNm } from "@/lib/geo";
 import { evaluateWarning } from "@/lib/speed-warning";
+import { fmtAgoTs } from "@/lib/time";
 import type { HotZone } from "@/lib/hotzones";
 import { StatusPill } from "./StatusPill";
 import { Card } from "./Card";
@@ -421,7 +422,7 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
           marginTop: 2,
         }}
       >
-        {fmtRelative(entry.ts)}
+        {fmtAgoTs(entry.ts)}
       </span>
       <span style={{ flex: 1, fontSize: 12.5, color: SS_TOKENS.fg1, lineHeight: 1.4 }}>
         {entry.description}
@@ -430,13 +431,3 @@ function ActivityRow({ entry }: { entry: ActivityEntry }) {
   );
 }
 
-function fmtRelative(tsSec: number): string {
-  const seconds = Math.max(0, Math.floor(Date.now() / 1000 - tsSec));
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}

--- a/components/Glanceable.tsx
+++ b/components/Glanceable.tsx
@@ -6,7 +6,7 @@ import type { Aircraft, FleetEntry, Snapshot } from "@/lib/types";
 import type { ActivityEntry } from "@/lib/activity";
 import type { LearningState } from "@/lib/learning";
 import { SS_TOKENS } from "@/lib/tokens";
-import { fmtAloft } from "@/lib/time";
+import { fmtAgoTs, fmtAloft } from "@/lib/time";
 import { useAircraft } from "@/lib/hooks/useAircraft";
 import { computeStatus, type StatusState } from "@/lib/status";
 import { StatusPill } from "./StatusPill";
@@ -304,20 +304,10 @@ function ActivityStrip({ latest }: { latest: ActivityEntry }) {
         className="ss-mono"
         style={{ fontSize: 11, color: SS_TOKENS.fg2, flexShrink: 0 }}
       >
-        {fmtRelativeStrip(latest.ts)}
+        {fmtAgoTs(latest.ts)}
       </span>
     </Link>
   );
-}
-
-function fmtRelativeStrip(tsMs: number): string {
-  const seconds = Math.max(0, Math.floor((Date.now() - tsMs) / 1000));
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function Hero({ status }: { status: StatusState }) {

--- a/lib/time.test.ts
+++ b/lib/time.test.ts
@@ -1,0 +1,20 @@
+// Run: npx tsx --test lib/time.test.ts
+//
+// Pins the contract for fmtAgoTs against the regression that shipped on
+// /dash: a forked formatter treated millisecond timestamps as seconds and
+// collapsed every Recent activity row into "just now". The activity feed
+// (lib/activity.ts) emits ms-since-epoch, so callers must read ms here too.
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { fmtAgoTs } from "./time";
+
+test("fmtAgoTs: 5h-old ms timestamp renders as '5h ago' (regression — must not be 'just now')", () => {
+  const fiveHoursAgoMs = Date.now() - 5 * 60 * 60 * 1000;
+  assert.equal(fmtAgoTs(fiveHoursAgoMs), "5h ago");
+});
+
+test("fmtAgoTs: 30s-old ms timestamp renders as 'just now'", () => {
+  const thirtySecAgoMs = Date.now() - 30 * 1000;
+  assert.equal(fmtAgoTs(thirtySecAgoMs), "just now");
+});


### PR DESCRIPTION
## Summary

Fixes the "just now" bug visible on `/dash` "Recent activity" — every row was rendering "just now" because `DashShell.tsx` reimplemented `fmtRelative(tsSec)` and treated the millisecond timestamp as seconds. Routes the dash through the canonical `fmtAgoTs` in `lib/time.ts` and does the same cleanup on `Glanceable.tsx` to prevent the next drift.

## Verification

- `npm run build` clean
- `npx tsc --noEmit` clean
- Unit test added covering the regression (`lib/time.test.ts`): 5h-old ms timestamp → `5h ago`, 30s-old → `just now`. Run via `npx tsx --test lib/time.test.ts` (matches the existing `lib/icao.test.ts` convention)
- **Did not** boot the dev server / observe `/dash` locally — leaving the visual confirm to the Vercel preview

## Things Alex needs to do

- [ ] Review the Vercel preview `/dash` and confirm Recent activity timestamps render with mixed Xm/Xh/Xd ago (not all "just now")
- [ ] Merge manually when satisfied — no auto-merge

## Out of scope

- Activity API (already returns ms; no change)
- `/activity` page (already uses fmtAgoTs)
- Brand voice review (output strings unchanged — same "just now" / "Xm ago" / "Xh ago" / "Xd ago" tokens)