### PR TITLE
fix(settings): redirect /settings to /settings/alerts instead of 404

### DIFF
--- a/app/(tabs)/settings/page.tsx
+++ b/app/(tabs)/settings/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: "Settings",
+};
+
+export default function SettingsIndex() {
+  redirect("/settings/alerts");
+}


### PR DESCRIPTION
## Summary

Adds `app/(tabs)/settings/page.tsx` with a server-side redirect to `/settings/alerts`. Bare `/settings` was returning the 404 "Lost your signal" page because no index existed.

## Verification

- `npm run build` clean — `/settings` now appears in the route table; `/settings/alerts` and `/settings/zones` unchanged
- `npx tsc --noEmit` clean
- Did not boot the dev server locally — leaving the visual confirm to the Vercel preview

## Things Alex needs to do

- [ ] Click `/settings` on the Vercel preview and confirm it lands on Alerts
- [ ] Merge manually when satisfied — no auto-merge

## Out of scope

- Adding a real settings hub UI with both Alerts + Zones tiles. Could be a future improvement, but the redirect is the minimum-friction fix for the 404.